### PR TITLE
Avoid pid collisions.

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,8 +299,12 @@ NYC.prototype.writeCoverageFile = function () {
     coverage = this.sourceMapTransform(coverage)
   }
 
+  var id = md5hex(
+    process.hrtime().concat(process.pid).map(String)
+  )
+
   fs.writeFileSync(
-    path.resolve(this.tempDirectory(), './', process.pid + '.json'),
+    path.resolve(this.tempDirectory(), './', id + '.json'),
     JSON.stringify(coverage),
     'utf-8'
   )


### PR DESCRIPTION
With AVA's concurrency flag, it's possible that two processes during a test run will share the same pid.

Avoid this collision by hashing the pid with process.hrtime for a truly unique value.