### PR TITLE
fix: disable the babel/nyc cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nyc
 
 [![Build Status](https://travis-ci.org/istanbuljs/nyc.svg?branch=master)](https://travis-ci.org/istanbuljs/nyc)
-[![Coverage Status](https://coveralls.io/repos/istanbuljs/nyc/badge.svg?branch=)](https://coveralls.io/r/istanbuljs/nyc?branch=master)
+[![Coverage Status](https://coveralls.io/repos/bcoe/nyc/badge.svg?branch=)](https://coveralls.io/r/bcoe/nyc?branch=master)
 [![NPM version](https://img.shields.io/npm/v/nyc.svg)](https://www.npmjs.com/package/nyc)
 [![Windows Tests](https://img.shields.io/appveyor/ci/bcoe/nyc-ilw23/master.svg?label=Windows%20Tests)](https://ci.appveyor.com/project/bcoe/nyc-ilw23)
 [![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -87,7 +87,7 @@ var yargs = require('yargs/yargs')(process.argv.slice(2))
   })
   .option('cache', {
     alias: 'c',
-    default: true,
+    default: false,
     type: 'boolean',
     describe: 'cache instrumentation results for improved performance'
   })
@@ -174,7 +174,8 @@ if (argv._[0] === 'report') {
     NYC_CWD: process.cwd(),
     NYC_CACHE: argv.cache ? 'enable' : 'disable',
     NYC_SOURCE_MAP: argv.sourceMap ? 'enable' : 'disable',
-    NYC_INSTRUMENTER: argv.instrumenter
+    NYC_INSTRUMENTER: argv.instrumenter,
+    BABEL_DISABLE_CACHE: 1
   }
   if (argv.require.length) {
     env.NYC_REQUIRE = argv.require.join(',')

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "index.js",
     "bin/*.js",
     "lib/*.js",
+    "lib/commands/*.js",
     "lib/instrumenters/*.js",
     "!**/*covered.js"
   ],


### PR DESCRIPTION
the interactions between the ava, babel, and nyc cache were causing a lot of confusion for folks, see:

https://github.com/istanbuljs/nyc/issues/296
https://github.com/istanbuljs/nyc/issues/294

In this pull request:

* we leave nyc's cache as opt in (I was considering making it run by default in 7.x).
* we disable babel's cache when running tests with nyc (this cache caused a lot of issues with babel-plugin-istanbul).