### PR TITLE
fix: babylon misconfiguration

### DIFF
--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -3,6 +3,7 @@ function InstrumenterIstanbul (cwd) {
 
   return istanbul.createInstrumenter({
     autoWrap: true,
+    esModules: true,
     coverageVariable: '__coverage__',
     embedSource: true,
     noCompact: false,


### PR DESCRIPTION
When using ES6 modules in source/test code, I get this message: 

```
failed to instrument /Users/kdodds/Developer/starwars-names/src/index.js with error: 'import' and 'export' may appear only with 'sourceType: module' (1:0)
```

The coverage report is still generated, but I think that we probably don't want this error message. Let me know if I'm misunderstanding something.