### PR TITLE
Handles correct path casing. Fixes #269.

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,6 +287,7 @@ NYC.prototype._handleSourceMap = function (cacheDir, code, hash, filename) {
 
 NYC.prototype._handleJs = function (code, filename) {
   var relFile = path.relative(this.cwd, filename)
+  filename = path.resolve(this.cwd, relFile) // ensure the path has correct casing (see https://github.com/istanbuljs/nyc/issues/269)
   return this._maybeInstrumentSource(code, filename, relFile) || code
 }
 

--- a/index.js
+++ b/index.js
@@ -287,7 +287,8 @@ NYC.prototype._handleSourceMap = function (cacheDir, code, hash, filename) {
 
 NYC.prototype._handleJs = function (code, filename) {
   var relFile = path.relative(this.cwd, filename)
-  filename = path.resolve(this.cwd, relFile) // ensure the path has correct casing (see https://github.com/istanbuljs/nyc/issues/269)
+  // ensure the path has correct casing (see istanbuljs/nyc#269 and nodejs/node#6624)
+  filename = path.resolve(this.cwd, relFile)
   return this._maybeInstrumentSource(code, filename, relFile) || code
 }
 


### PR DESCRIPTION
A simple fix that forces the provided absolute path to use `this.cwd` instead. This is a windows only fix, so let me know if it should be wrapped in a `if` statement for platform checks.