### PR TITLE
feat: nyc no longer tries to run arguments passed to the instrumented bin

### DIFF
--- a/index.js
+++ b/index.js
@@ -473,10 +473,4 @@ NYC.prototype.tempDirectory = function () {
   return path.resolve(this.cwd, './', this._tempDirectory)
 }
 
-NYC.prototype.mungeArgs = function (yargv) {
-  var argv = process.argv.slice(1)
-  argv = argv.slice(argv.indexOf(yargv._[0]))
-  return argv
-}
-
 module.exports = NYC

--- a/lib/process-args.js
+++ b/lib/process-args.js
@@ -1,0 +1,33 @@
+var parser = require('yargs-parser')
+var commands = [
+  'report',
+  'check-coverage',
+  'instrument'
+]
+
+module.exports = {
+  // don't pass arguments that are meant
+  // for nyc to the bin being instrumented.
+  hideInstrumenterArgs: function (yargv) {
+    var argv = process.argv.slice(1)
+    argv = argv.slice(argv.indexOf(yargv._[0]))
+    return argv
+  },
+  // don't pass arguments for the bin being
+  // instrumented to nyc.
+  hideInstrumenteeArgs: function () {
+    var argv = process.argv.slice(2)
+    var yargv = parser(argv)
+    if (!yargv._.length) return argv
+    for (var i = 0, command; (command = yargv._[i]) !== undefined; i++) {
+      if (~commands.indexOf(command)) return argv
+    }
+
+    // drop all the arguments after the bin being
+    // instrumented by nyc.
+    argv = argv.slice(0, argv.indexOf(yargv._[0]))
+    argv.push(yargv._[0])
+
+    return argv
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf ./.nyc_output ./node_modules/.cache ./.self_coverage ./test/fixtures/.nyc_output ./test/fixtures/node_modules/.cache *covered.js ./lib/*covered.js",
     "build": "node ./build-tests",
     "instrument": "node ./build-self-coverage.js",
-    "run-tests": "tap -t120 --no-cov -b ./test/build/*.js ./test/src/nyc-bin.js",
+    "run-tests": "tap -t120 --no-cov -b ./test/build/*.js ./test/src/nyc-bin.js ./test/src/process-args.js",
     "report": "node ./bin/nyc  --temp-directory ./.self_coverage/ -r text -r lcov report",
     "cover": "npm run clean && npm run build && npm run instrument && npm run run-tests && npm run report",
     "dev": "npm run clean && npm run build && npm run run-tests",
@@ -95,7 +95,8 @@
     "signal-exit": "^3.0.0",
     "spawn-wrap": "^1.2.4",
     "test-exclude": "^1.1.0",
-    "yargs": "^4.8.0"
+    "yargs": "^4.8.1",
+    "yargs-parser": "^2.4.0"
   },
   "devDependencies": {
     "any-path": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "spawn-wrap": "^1.2.4",
     "test-exclude": "^1.1.0",
     "yargs": "^4.8.1",
-    "yargs-parser": "^2.4.0"
+    "yargs-parser": "^2.4.1"
   },
   "devDependencies": {
     "any-path": "^1.3.0",
@@ -124,7 +124,6 @@
     "url": "git@github.com:bcoe/nyc.git"
   },
   "bundledDependencies": [
-    "append-transform",
     "arrify",
     "caching-transform",
     "convert-source-map",
@@ -134,8 +133,8 @@
     "foreground-child",
     "glob",
     "istanbul-lib-coverage",
-    "istanbul-lib-instrument",
     "istanbul-lib-hook",
+    "istanbul-lib-instrument",
     "istanbul-lib-report",
     "istanbul-lib-source-maps",
     "istanbul-reports",
@@ -148,6 +147,7 @@
     "signal-exit",
     "spawn-wrap",
     "test-exclude",
-    "yargs"
+    "yargs",
+    "yargs-parser"
   ]
 }

--- a/test/fixtures/cli/args.js
+++ b/test/fixtures/cli/args.js
@@ -1,0 +1,1 @@
+console.log(JSON.stringify(process.argv))

--- a/test/src/nyc-bin.js
+++ b/test/src/nyc-bin.js
@@ -410,4 +410,29 @@ describe('the nyc cli', function () {
       })
     })
   })
+
+  describe('args', function () {
+    it('does not interpret args intended for instrumented bin', function (done) {
+      var args = [bin, '--silent', process.execPath, 'args.js', '--help', '--version']
+
+      var proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      var stdout = ''
+      proc.stdout.on('data', function (chunk) {
+        stdout += chunk
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(0)
+        var args = JSON.parse(stdout)
+        args.should.include('--help')
+        args.should.include('--version')
+        args.should.not.include('--silent')
+        done()
+      })
+    })
+  })
 })

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -339,24 +339,6 @@ describe('nyc', function () {
     })
   })
 
-  describe('mungeArgs', function () {
-    it('removes dashed options that proceed bin', function () {
-      process.argv = ['/Users/benjamincoe/bin/iojs',
-        '/Users/benjamincoe/bin/nyc.js',
-        '--reporter',
-        'lcov',
-        'node',
-        'test/nyc-test.js'
-      ]
-
-      var yargv = require('yargs/yargs')(process.argv.slice(2)).argv
-
-      var munged = (new NYC()).mungeArgs(yargv)
-
-      munged.should.eql(['node', 'test/nyc-test.js'])
-    })
-  })
-
   describe('addAllFiles', function () {
     it('outputs an empty coverage report for all files that are not excluded', function (done) {
       var nyc = new NYC({

--- a/test/src/process-args.js
+++ b/test/src/process-args.js
@@ -1,0 +1,65 @@
+/* global describe, it */
+
+require('chai').should()
+require('tap').mochaGlobals()
+
+const processArgs = require('../../lib/process-args')
+
+describe('process-args', function () {
+  describe('hideInstrumenterArgs', function () {
+    it('removes dashed options that proceed bin', function () {
+      process.argv = ['/Users/benjamincoe/bin/iojs',
+        '/Users/benjamincoe/bin/nyc.js',
+        '--reporter',
+        'lcov',
+        'node',
+        'test/nyc-test.js'
+      ]
+
+      var yargv = require('yargs/yargs')(process.argv.slice(2)).argv
+
+      var munged = processArgs.hideInstrumenterArgs(yargv)
+
+      munged.should.eql(['node', 'test/nyc-test.js'])
+    })
+  })
+
+  describe('hideInstrumenteeArgs', function () {
+    it('ignores arguments after the instrumented bin', function () {
+      process.argv = ['/Users/benjamincoe/bin/iojs',
+        '/Users/benjamincoe/bin/nyc.js',
+        '--reporter',
+        'lcov',
+        'node',
+        'test/nyc-test.js',
+        '--arg',
+        '--'
+      ]
+
+      var munged = processArgs.hideInstrumenteeArgs()
+      munged.should.eql(['--reporter', 'lcov', 'node'])
+    })
+
+    it('does not ignore arguments if command is recognized', function () {
+      process.argv = ['/Users/benjamincoe/bin/iojs',
+        '/Users/benjamincoe/bin/nyc.js',
+        'report',
+        '--reporter',
+        'lcov'
+      ]
+
+      var munged = processArgs.hideInstrumenteeArgs()
+      munged.should.eql(['report', '--reporter', 'lcov'])
+    })
+
+    it('does not ignore arguments if no command is provided', function () {
+      process.argv = ['/Users/benjamincoe/bin/iojs',
+        '/Users/benjamincoe/bin/nyc.js',
+        '--version'
+      ]
+
+      var munged = processArgs.hideInstrumenteeArgs()
+      munged.should.eql(['--version'])
+    })
+  })
+})


### PR DESCRIPTION
This pull request is an attempt to make nyc's argument parsing more clever, in the past:

`nyc npm test --silent`

would have resulted in `nyc` itself reading the `--silent` flag, and failing to print output.

With this fix, nyc instead parses:

`nyc npm test`, dropping the trailing arguments.

fixes: #99, #201 

Reviewers: @MoOx, @jamestalmage, @danez, @JaKXz 