### PR TITLE
Make --all flag work with files with extensions other than .js

### DIFF
--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ NYC.prototype.addFile = function (filename) {
 NYC.prototype._readTranspiledSource = function (filePath) {
   var source = null
   var ext = path.extname(filePath)
-  if (Module._extensions[ext] === 'undefined') {
+  if (typeof Module._extensions[ext] === 'undefined') {
     ext = '.js'
   }
   Module._extensions[ext]({

--- a/index.js
+++ b/index.js
@@ -143,13 +143,14 @@ NYC.prototype.addFile = function (filename) {
   }
 }
 
-NYC.prototype._readTranspiledSource = function (path) {
+NYC.prototype._readTranspiledSource = function (filePath) {
   var source = null
-  Module._extensions['.js']({
+  var ext = path.extname(filePath)
+  Module._extensions[ext]({
     _compile: function (content, filename) {
       source = content
     }
-  }, path)
+  }, filePath)
   return source
 }
 

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ NYC.prototype._readTranspiledSource = function (filePath) {
   var source = null
   var ext = path.extname(filePath)
   if (Module._extensions[ext] === 'undefined') {
-    ext = '.js';
+    ext = '.js'
   }
   Module._extensions[ext]({
     _compile: function (content, filename) {

--- a/index.js
+++ b/index.js
@@ -146,6 +146,9 @@ NYC.prototype.addFile = function (filename) {
 NYC.prototype._readTranspiledSource = function (filePath) {
   var source = null
   var ext = path.extname(filePath)
+  if (Module._extensions[ext] === 'undefined') {
+    ext = '.js';
+  }
   Module._extensions[ext]({
     _compile: function (content, filename) {
       source = content


### PR DESCRIPTION
I'm using TypeScript for a project, and when I run nyc with the *--all* flag, I keep getting errors such as:

*failed to instrument /microservices/ms-gateway/app/entities/UserEndpoint.ts with error: 'import' and 'export' may appear only with 'sourceType: module' (1:0)*

My package.json config looks like this:

```json
"nyc": {
    "include": [
      "app/*.ts",
      "app/**/*.ts"
    ],
    "extension": [
      ".ts"
    ],
    "require": [
      "ts-node/register"
    ]
  }
```
It happens because under the hood, the code was trying to instrument the TypeScript code rather than the transpiled JavaScript code.