### PR TITLE
Make `nyc instrument` work in subdirectories

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
   var visitor = function (filename) {
     var ext
     var transform
-    var inFile = path.relative(_this.cwd, path.resolve(inputDir, filename))
+    var inFile = path.resolve(inputDir, filename)
     var code = fs.readFileSync(inFile, 'utf-8')
 
     for (ext in _this.transforms) {
@@ -200,7 +200,7 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
     if (!output) {
       console.log(code)
     } else {
-      var outFile = path.relative(_this.cwd, path.resolve(output, filename))
+      var outFile = path.resolve(output, filename)
       mkdirp.sync(path.dirname(outFile))
       fs.writeFileSync(outFile, code, 'utf-8')
     }

--- a/test/fixtures/cli/subdir/.gitignore
+++ b/test/fixtures/cli/subdir/.gitignore
@@ -1,0 +1,1 @@
+output-dir

--- a/test/fixtures/cli/subdir/input-dir/index.js
+++ b/test/fixtures/cli/subdir/input-dir/index.js
@@ -1,0 +1,2 @@
+'use strict';
+console.log('Hello, World!')

--- a/test/src/nyc-bin.js
+++ b/test/src/nyc-bin.js
@@ -16,6 +16,7 @@ require('tap').mochaGlobals()
 // beforeEach
 rimraf.sync(path.resolve(fakebin, 'node'))
 rimraf.sync(path.resolve(fakebin, 'npm'))
+rimraf.sync(path.resolve(fixturesCLI, 'subdir', 'output-dir'))
 
 describe('the nyc cli', function () {
   var env = { PATH: process.env.PATH }
@@ -336,6 +337,24 @@ describe('the nyc cli', function () {
           stdout.should.match(/half-covered\.js"/)
           stdout.should.match(/half-covered-failing\.js"/)
           stdout.should.not.match(/spawn\.js"/)
+          done()
+        })
+      })
+
+      it('works in directories without a package.json', function (done) {
+        var args = [bin, 'instrument', './input-dir', './output-dir']
+
+        var subdir = path.resolve(fixturesCLI, 'subdir')
+        var proc = spawn(process.execPath, args, {
+          cwd: subdir,
+          env: env
+        })
+
+        proc.on('exit', function (code) {
+          code.should.equal(0)
+          var target = path.resolve(subdir, 'output-dir', 'index.js')
+          fs.readFileSync(target, 'utf8')
+              .should.match(/console.log\('Hello, World!'\)/)
           done()
         })
       })


### PR DESCRIPTION
Hi everyone! Ran into a problem running `nyc instrument` today, and it would be cool if you could take a look at. I’m pretty sure this is a correct fix, but still, removing code always comes with the suspicion that there is a reason it was there in the first place. ;)

------

There is no real reason to use a relative path when performing the I/O for instrumenting. Absolute paths should work just as well and will be correct, even when `nyc.cwd` is off a bit because it is modified based on what `pkgUp` says.