### PR TITLE
feat: upgrade to new test-exclude; with suppport for node_modules

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -10,6 +10,7 @@ try {
 var processArgs = require('../lib/process-args')
 
 var sw = require('spawn-wrap')
+var testExclude = require('test-exclude')
 var wrapper = require.resolve('./wrap.js')
 var Yargs = require('yargs/yargs')
 
@@ -183,7 +184,7 @@ function buildYargs () {
     })
     .option('exclude', {
       alias: 'x',
-      default: [],
+      default: testExclude.defaultExclude,
       describe: 'a list of specific files and directories that should be excluded from coverage, glob patterns are supported, node_modules is always excluded'
     })
     .option('include', {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rimraf": "^2.5.4",
     "signal-exit": "^3.0.0",
     "spawn-wrap": "^1.2.4",
-    "test-exclude": "^1.1.0",
+    "test-exclude": "^2.1.1",
     "yargs": "^4.8.1",
     "yargs-parser": "^3.1.0"
   },

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -69,7 +69,7 @@ describe('nyc', function () {
         cwd: path.resolve(__dirname, '../fixtures')
       })
 
-      nyc.exclude.exclude.length.should.eql(5)
+      nyc.exclude.exclude.length.should.eql(4)
     })
 
     it("loads 'extension' patterns from package.json#nyc", function () {
@@ -95,19 +95,21 @@ describe('nyc', function () {
       nyc2.exclude.include.should.equal(false)
     })
 
-    it("ignores 'exclude' option if it's falsy or []", function () {
+    it("ignores 'exclude' option if it's falsy", function () {
       var nyc1 = new NYC({
         cwd: path.resolve(__dirname, '../fixtures/conf-empty')
       })
 
       nyc1.exclude.exclude.length.should.eql(7)
+    })
 
+    it("allows for empty 'exclude'", function () {
       var nyc2 = new NYC({
         cwd: path.resolve(__dirname, '../fixtures/conf-empty'),
         exclude: []
       })
 
-      nyc2.exclude.exclude.length.should.eql(7)
+      nyc2.exclude.exclude.length.should.eql(0)
     })
   })
 


### PR DESCRIPTION
BREAKING CHANGE: node_modules is no longer automatically excluded, and an empty array of exclude rules can be provided.