### PR TITLE
Implicitly assume `node` when the command starts with an option

### DIFF
--- a/lib/process-args.js
+++ b/lib/process-args.js
@@ -11,6 +11,9 @@ module.exports = {
   hideInstrumenterArgs: function (yargv) {
     var argv = process.argv.slice(1)
     argv = argv.slice(argv.indexOf(yargv._[0]))
+    if (argv[0][0] === '-') {
+      argv.unshift(process.execPath)
+    }
     return argv
   },
   // don't pass arguments for the bin being

--- a/test/fixtures/cli/gc.js
+++ b/test/fixtures/cli/gc.js
@@ -1,0 +1,3 @@
+'use strict';
+gc();
+console.log('I’m still running');

--- a/test/src/nyc-bin.js
+++ b/test/src/nyc-bin.js
@@ -453,5 +453,26 @@ describe('the nyc cli', function () {
         done()
       })
     })
+
+    it('interprets first args after -- as Node.js execArgv', function (done) {
+      var args = [bin, '--', '--expose-gc', path.resolve(fixturesCLI, 'gc.js')]
+
+      var proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      var stdout = ''
+      proc.stdout.setEncoding('utf8')
+      proc.stdout.on('data', function (chunk) {
+        stdout += chunk
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(0)
+        stdout.should.include('still running')
+        done()
+      })
+    })
   })
 })

--- a/test/src/process-args.js
+++ b/test/src/process-args.js
@@ -22,6 +22,21 @@ describe('process-args', function () {
 
       munged.should.eql(['node', 'test/nyc-test.js'])
     })
+
+    it('parses extra args directly after -- as Node execArgv', function () {
+      process.argv = ['/Users/benjamincoe/bin/iojs',
+        '/Users/benjamincoe/bin/nyc.js',
+        '--',
+        '--expose-gc',
+        'index.js'
+      ]
+
+      var yargv = require('yargs/yargs')(process.argv.slice(2)).argv
+
+      var munged = processArgs.hideInstrumenterArgs(yargv)
+
+      munged.should.eql([process.execPath, '--expose-gc', 'index.js'])
+    })
   })
 
   describe('hideInstrumenteeArgs', function () {


### PR DESCRIPTION
Assume that commands starting with `-`, e.g. `--expose-gc script.js`, implicitly are Node.js commands.

Fixes: https://github.com/istanbuljs/nyc/issues/337

While on the one hand I’m not sure if this isn’t handled better on `tap`’s side, I *think* this makes sense anyway.