### PR TITLE
docs(README): `node_modules` is no longer excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,6 @@ the array is a glob pattern indicating which paths should be omitted.
 
 Globs are matched using [micromatch](https://www.npmjs.com/package/micromatch).
 
-In addition to patterns specified in the package, nyc will always exclude
-files in `node_modules`.
-
 For example, the following config will exclude everything in `node_modules`,
 any files with the extension `.spec.js`, and anything in the `build`
 directory:


### PR DESCRIPTION
via [v8.0.0](https://github.com/istanbuljs/nyc/blob/master/CHANGELOG.md#800-2016-08-12)

Please let me know if I understood this correctly :)

And if you don’t mind me asking here, for a setup like this one:
https://github.com/hoodiehq/spawn-pouchdb-server/blob/master/package.json#L6

Should I know exclude `node_modules`?