### PR TITLE
feat: gather process tree information

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,26 @@ __instrument the entire ./lib folder:__
 
 `nyc instrument ./lib ./output`
 
+## Process tree information
+
+nyc is able to show you all Node processes that are spawned when running a
+test script under it:
+
+```
+$ nyc --show-process-tree npm test
+   3 passed
+----------|----------|----------|----------|----------|----------------|
+File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
+----------|----------|----------|----------|----------|----------------|
+All files |      100 |      100 |      100 |      100 |                |
+ index.js |      100 |      100 |      100 |      100 |                |
+----------|----------|----------|----------|----------|----------------|
+nyc
+└─┬ /usr/local/bin/node /usr/local/bin/npm test
+  └─┬ /usr/local/bin/node /path/to/your/project/node_modules/.bin/ava
+    └── /usr/local/bin/node /path/to/your/project/node_modules/ava/lib/test-worker.js …
+```
+
 ## Integrating with coveralls
 
 [coveralls.io](https://coveralls.io) is a great tool for adding

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -44,7 +44,8 @@ if (argv._[0] === 'report') {
     exclude: argv.exclude,
     sourceMap: !!argv.sourceMap,
     instrumenter: argv.instrumenter,
-    hookRunInContext: argv.hookRunInContext
+    hookRunInContext: argv.hookRunInContext,
+    showProcessTree: argv.showProcessTree
   }))
   nyc.reset()
 
@@ -56,6 +57,8 @@ if (argv._[0] === 'report') {
     NYC_SOURCE_MAP: argv.sourceMap ? 'enable' : 'disable',
     NYC_INSTRUMENTER: argv.instrumenter,
     NYC_HOOK_RUN_IN_CONTEXT: argv.hookRunInContext ? 'enable' : 'disable',
+    NYC_SHOW_PROCESS_TREE: argv.showProcessTree ? 'enable' : 'disable',
+    NYC_ROOT_ID: nyc.rootId,
     BABEL_DISABLE_CACHE: 1
   }
   if (argv.require.length) {
@@ -101,11 +104,13 @@ if (argv._[0] === 'report') {
 function report (argv) {
   process.env.NYC_CWD = process.cwd()
 
-  ;(new NYC({
+  var nyc = new NYC({
     reporter: argv.reporter,
     reportDir: argv.reportDir,
-    tempDirectory: argv.tempDirectory
-  })).report()
+    tempDirectory: argv.tempDirectory,
+    showProcessTree: argv.showProcessTree
+  })
+  nyc.report()
 }
 
 function checkCoverage (argv, cb) {
@@ -137,6 +142,11 @@ function buildYargs () {
         .option('temp-directory', {
           describe: 'directory from which coverage JSON files are read',
           default: './.nyc_output'
+        })
+        .option('show-process-tree', {
+          describe: 'display the tree of spawned processes',
+          default: false,
+          type: 'boolean'
         })
         .example('$0 report --reporter=lcov', 'output an HTML lcov report to ./coverage')
     })
@@ -243,6 +253,11 @@ function buildYargs () {
       default: true,
       type: 'boolean',
       description: 'should nyc wrap vm.runInThisContext?'
+    })
+    .option('show-process-tree', {
+      describe: 'display the tree of spawned processes',
+      default: false,
+      type: 'boolean'
     })
     .pkgConf('nyc', process.cwd())
     .example('$0 npm test', 'instrument your tests with coverage')

--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -6,6 +6,9 @@ try {
   NYC = require('../index.js')
 }
 
+var parentPid = process.env.NYC_PARENT_PID || '0'
+process.env.NYC_PARENT_PID = process.pid
+
 ;(new NYC({
   require: process.env.NYC_REQUIRE ? process.env.NYC_REQUIRE.split(',') : [],
   extension: process.env.NYC_EXTENSION ? process.env.NYC_EXTENSION.split(',') : [],
@@ -14,7 +17,12 @@ try {
   enableCache: process.env.NYC_CACHE === 'enable',
   sourceMap: process.env.NYC_SOURCE_MAP === 'enable',
   instrumenter: process.env.NYC_INSTRUMENTER,
-  hookRunInContext: process.env.NYC_HOOK_RUN_IN_CONTEXT === 'enable'
+  hookRunInContext: process.env.NYC_HOOK_RUN_IN_CONTEXT === 'enable',
+  showProcessTree: process.env.NYC_SHOW_PROCESS_TREE === 'enable',
+  _processInfo: {
+    ppid: parentPid,
+    root: process.env.NYC_ROOT_ID
+  }
 })).wrap()
 
 sw.runMain()

--- a/build-self-coverage.js
+++ b/build-self-coverage.js
@@ -3,7 +3,8 @@ var fs = require('fs')
 var path = require('path')
 
 ;[
-  'index.js'
+  'index.js',
+  'lib/process.js'
 ].forEach(function (name) {
   var indexPath = path.join(__dirname, name)
   var source = fs.readFileSync(indexPath, 'utf8')

--- a/index.js
+++ b/index.js
@@ -446,9 +446,7 @@ NYC.prototype.report = function () {
 }
 
 NYC.prototype.showProcessTree = function () {
-  var processInfos = this._loadProcessInfos()
-
-  console.log(ProcessInfo.renderProcessTree(processInfos))
+  console.log(this._loadProcessInfoTree().render())
 }
 
 NYC.prototype.checkCoverage = function (thresholds) {
@@ -473,6 +471,10 @@ NYC.prototype.checkCoverage = function (thresholds) {
       console.error('ERROR: Coverage for ' + key + ' (' + coverage + '%) does not meet global threshold (' + thresholds[key] + '%)')
     }
   })
+}
+
+NYC.prototype._loadProcessInfoTree = function () {
+  return ProcessInfo.buildProcessTree(this._loadProcessInfos())
 }
 
 NYC.prototype._loadProcessInfos = function () {

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,0 +1,51 @@
+'use strict'
+var archy = require('archy')
+
+function ProcessInfo (defaults) {
+  defaults = defaults || {}
+
+  this.pid = String(process.pid)
+  this.argv = process.argv
+  this.execArgv = process.execArgv
+  this.cwd = process.cwd()
+  this.time = Date.now()
+  this.ppid = null
+  this.root = null
+  this.coverageFilename = null
+
+  for (var key in defaults) {
+    this[key] = defaults[key]
+  }
+}
+
+ProcessInfo.renderProcessTree = function (infos) {
+  var treeRoot = { label: 'nyc', nodes: [] }
+  var nodes = { }
+
+  infos = infos.sort(function (a, b) {
+    return a.time - b.time
+  })
+
+  infos.forEach(function (p) {
+    nodes[p.root + ':' + p.pid] = p
+    p.nodes = [] // list of children
+    p.label = p.argv.join(' ')
+  })
+
+  infos.forEach(function (p) {
+    if (!p.ppid) {
+      return
+    }
+
+    var parent = nodes[p.root + ':' + p.ppid]
+    if (!parent) {
+      parent = treeRoot
+    }
+
+    parent.nodes.push(p)
+  })
+
+  return archy(treeRoot)
+}
+
+module.exports = ProcessInfo

--- a/lib/process.js
+++ b/lib/process.js
@@ -12,14 +12,25 @@ function ProcessInfo (defaults) {
   this.ppid = null
   this.root = null
   this.coverageFilename = null
+  this.nodes = [] // list of children, filled by buildProcessTree()
 
   for (var key in defaults) {
     this[key] = defaults[key]
   }
 }
 
-ProcessInfo.renderProcessTree = function (infos) {
-  var treeRoot = { label: 'nyc', nodes: [] }
+Object.defineProperty(ProcessInfo.prototype, 'label', {
+  get: function () {
+    if (this._label) {
+      return this._label
+    }
+
+    return this.argv.join(' ')
+  }
+})
+
+ProcessInfo.buildProcessTree = function (infos) {
+  var treeRoot = new ProcessInfo({ _label: 'nyc' })
   var nodes = { }
 
   infos = infos.sort(function (a, b) {
@@ -28,8 +39,6 @@ ProcessInfo.renderProcessTree = function (infos) {
 
   infos.forEach(function (p) {
     nodes[p.root + ':' + p.pid] = p
-    p.nodes = [] // list of children
-    p.label = p.argv.join(' ')
   })
 
   infos.forEach(function (p) {
@@ -45,7 +54,11 @@ ProcessInfo.renderProcessTree = function (infos) {
     parent.nodes.push(p)
   })
 
-  return archy(treeRoot)
+  return treeRoot
+}
+
+ProcessInfo.prototype.render = function () {
+  return archy(this)
 }
 
 module.exports = ProcessInfo

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "dependencies": {
+    "archy": "^1.0.0",
     "arrify": "^1.0.1",
     "caching-transform": "^1.0.0",
     "convert-source-map": "^1.3.0",
@@ -124,6 +125,7 @@
     "url": "git@github.com:istanbuljs/nyc.git"
   },
   "bundledDependencies": [
+    "archy",
     "arrify",
     "caching-transform",
     "convert-source-map",

--- a/test/fixtures/cli/selfspawn-fibonacci.js
+++ b/test/fixtures/cli/selfspawn-fibonacci.js
@@ -1,0 +1,30 @@
+'use strict';
+var cp = require('child_process');
+
+var index = +process.argv[2] || 0
+if (index <= 1) {
+  console.log(0)
+  return
+}
+if (index == 2) {
+  console.log(1)
+  return
+}
+
+function getFromChild(n, cb) {
+  var proc = cp.spawn(process.execPath, [__filename, n])
+  var stdout = ''
+  proc.stdout.on('data', function (data) { stdout += data })
+  proc.on('close', function () {
+    cb(null, +stdout)
+  })
+  proc.on('error', cb)
+}
+
+getFromChild(index - 1, function(err, result1) {
+  if (err) throw err
+  getFromChild(index - 2, function(err, result2) {
+    if (err) throw err
+    console.log(result1 + result2)
+  })
+})

--- a/test/src/nyc-bin.js
+++ b/test/src/nyc-bin.js
@@ -475,4 +475,55 @@ describe('the nyc cli', function () {
       })
     })
   })
+
+  describe('--show-process-tree', function () {
+    it('displays a tree of spawned processes', function (done) {
+      var args = [bin, '--show-process-tree', process.execPath, 'selfspawn-fibonacci.js', '5']
+
+      var proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      var stdout = ''
+      proc.stdout.setEncoding('utf8')
+      proc.stdout.on('data', function (chunk) {
+        stdout += chunk
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(0)
+        stdout.should.match(new RegExp(
+          'nyc\n' +
+          '└─┬.*selfspawn-fibonacci.js 5\n' +
+          '  ├─┬.*selfspawn-fibonacci.js 4\n' +
+          '  │ ├─┬.*selfspawn-fibonacci.js 3\n' +
+          '  │ │ ├──.*selfspawn-fibonacci.js 2\n' +
+          '  │ │ └──.*selfspawn-fibonacci.js 1\n' +
+          '  │ └──.*selfspawn-fibonacci.js 2\n' +
+          '  └─┬.*selfspawn-fibonacci.js 3\n' +
+          '    ├──.*selfspawn-fibonacci.js 2\n' +
+          '    └──.*selfspawn-fibonacci.js 1\n'
+        ))
+        done()
+      })
+    })
+
+    it('doesn’t create the temp directory for process info files when not present', function (done) {
+      var args = [bin, process.execPath, 'selfspawn-fibonacci.js', '5']
+
+      var proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      proc.on('exit', function (code) {
+        code.should.equal(0)
+        fs.stat(path.resolve(fixturesCLI, '.nyc_output', 'processinfo'), function (err, stat) {
+          err.code.should.equal('ENOENT')
+          done()
+        })
+      })
+    })
+  })
 })


### PR DESCRIPTION
Add a `--show-process-tree` that shows a pretty tree of all spawned processes after `nyc` has run.

The data files for that are stored in `processinfo` are stored in `(temp directory)/processinfo` so that they don’t interfere with the fixed format of the coverage files.

Fixes: https://github.com/istanbuljs/nyc/issues/158

Right now this only displays the commands as they are being run, ex:

```
$ nyc --show-process-tree npm run pretest

> nyc@8.1.0 pretest /home/sqrt/src/nyc
> standard

----------|----------|----------|----------|----------|----------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------|----------|----------|----------|----------|----------------|
All files |  Unknown |  Unknown |  Unknown |  Unknown |                |
----------|----------|----------|----------|----------|----------------|
nyc
└─┬ /usr/local/bin/node /usr/local/bin/npm run pretest
  └── /usr/local/bin/node /home/xxxx/src/nyc/node_modules/.bin/standard
```

Note: Unlike described in the above issue, I’ve opted to leave environment variables out of the stored data because they may contain sensitive information and there have been cases of `.nyc_output` accidentally being published.

Any thoughts?