### PR TITLE
Mention caching caveat in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ You can run `nyc` with the optional `--cache` flag, to prevent it from
 instrumenting the same files multiple times. This can significantly
 improve runtime performance.
 
+Changing your nyc configuration may lead to a corrupt cache. If you're seeing strange errors after updating nyc or it's configuration, try manually wiping the cache directory (`node_modules/.cache/nyc` by default). 
+
 ## Configuring `nyc`
 
 Any configuration options that can be set via the command line can also be specified in the `nyc` stanza of your package.json (these will not affect `nyc` subcommands):


### PR DESCRIPTION
Added this note to the readme for anyone else that may happen across the issues I've had today.

I've just updated to `8.2.0-candidate2` and have experienced a range of hard to diagnose runtime errors in my tests, which only occurred when running `nyc`.

e.g.

`TypeError: Cannot read property '0' of undefined`
`TypeError: Cannot read property '1' of undefined`

The file and line number that these errors were reported to occur at would change without clear motive as I tried tweaking various settings in my nyc config. Sometimes it would error immediately, sometimes it would error halfway through the tests. I shook my fist at my computer at least once.

All errors went away immediately after I managed to locate and flush the nyc cache directory. The location of this directory is not currently documented afaik.

I'm guessing that the cause of these issues is that the cache had been populated with data using an old, incorrect or incompatible nyc configuration/version.

Would be neat if the cache were invalidated automatically if the nyc version or nyc config changes between runs.