### PR TITLE
Add produceSourceMap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ and a `text-lcov` coverage report.
 nyc --reporter=lcov --reporter=text-lcov npm test
 ```
 
+## Stack Traces
+
+When `source-map` handling enabled, then the instrumented source files will
+include inline source maps for the instrumenter transform. When combined with
+a supporting version of [source-map-support](https://github.com/evanw/node-source-map-support/pull/118)
+(currently published under `@kpdecker/source-map-support` while PR pending),
+stack traces for instrumented code should reflect the original lines.
+
+This is enabled by default, but may be disabled by `nyc --source-map=false`.
+
 ## Support for custom require hooks (babel, webpack, etc.)
 
 nyc supports custom require hooks like

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ nyc --reporter=lcov --reporter=text-lcov npm test
 
 When `source-map` handling enabled, then the instrumented source files will
 include inline source maps for the instrumenter transform. When combined with
-a supporting version of [source-map-support](https://github.com/evanw/node-source-map-support/pull/118)
-(currently published under `@kpdecker/source-map-support` while PR pending),
+[source-map-support](https://github.com/evanw/node-source-map-support),
 stack traces for instrumented code should reflect the original lines.
 
 This is enabled by default, but may be disabled by `nyc --source-map=false`.

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var rimraf = require('rimraf')
 var onExit = require('signal-exit')
 var resolveFrom = require('resolve-from')
 var convertSourceMap = require('convert-source-map')
+var mergeSourceMap = require('merge-source-map')
 var md5hex = require('md5-hex')
 var findCacheDir = require('find-cache-dir')
 var js = require('default-require-extensions/js')
@@ -253,19 +254,30 @@ NYC.prototype._transformFactory = function (cacheDir) {
 
   return function (code, metadata, hash) {
     var filename = metadata.filename
+    var sourceMap
 
-    if (_this._sourceMap) _this._handleSourceMap(cacheDir, code, hash, filename)
+    if (_this._sourceMap) {
+      sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename))
+
+      _this._handleSourceMap(cacheDir, code, hash, filename, sourceMap)
+    }
 
     try {
       instrumented = instrumenter.instrumentSync(code, filename)
 
       var lastSourceMap = instrumenter.lastSourceMap()
       if (lastSourceMap) {
+        if (sourceMap) {
+          lastSourceMap = mergeSourceMap(
+                sourceMap.toObject(),
+                lastSourceMap)
+        }
+
         instrumented += '\n' + convertSourceMap.fromObject(lastSourceMap).toComment()
       }
     } catch (e) {
       // don't fail external tests due to instrumentation bugs.
-      console.warn('failed to instrument', filename, 'with error:', e.message)
+      console.warn('failed to instrument', filename, 'with error:', e.stack)
       instrumented = code
     }
 
@@ -277,8 +289,7 @@ NYC.prototype._transformFactory = function (cacheDir) {
   }
 }
 
-NYC.prototype._handleSourceMap = function (cacheDir, code, hash, filename) {
-  var sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename))
+NYC.prototype._handleSourceMap = function (cacheDir, code, hash, filename, sourceMap) {
   if (sourceMap) {
     if (hash) {
       var mapPath = path.join(cacheDir, hash + '.map')

--- a/index.js
+++ b/index.js
@@ -41,7 +41,6 @@ function NYC (config) {
   this._instrumenterLib = require(config.instrumenter || './lib/instrumenters/istanbul')
   this._reportDir = config.reportDir || 'coverage'
   this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true
-  this._produceSourceMap = typeof config.produceSourceMap !== 'undefined' ? config.produceSourceMap : 'inline'
   this._showProcessTree = config.showProcessTree || false
   this.cwd = config.cwd || process.cwd()
 
@@ -123,7 +122,7 @@ NYC.prototype.instrumenter = function () {
 
 NYC.prototype._createInstrumenter = function () {
   return this._instrumenterLib(this.cwd, {
-    produceSourceMap: this._produceSourceMap
+    produceSourceMap: this._sourceMap ? 'inline' : ''
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ function NYC (config) {
   this._instrumenterLib = require(config.instrumenter || './lib/instrumenters/istanbul')
   this._reportDir = config.reportDir || 'coverage'
   this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true
+  this._produceSourceMap = typeof config.produceSourceMap !== 'undefined' ? config.produceSourceMap : 'inline'
   this._showProcessTree = config.showProcessTree || false
   this.cwd = config.cwd || process.cwd()
 
@@ -120,7 +121,9 @@ NYC.prototype.instrumenter = function () {
 }
 
 NYC.prototype._createInstrumenter = function () {
-  return this._instrumenterLib(this.cwd)
+  return this._instrumenterLib(this.cwd, {
+    produceSourceMap: this._produceSourceMap
+  })
 }
 
 NYC.prototype.addFile = function (filename) {
@@ -255,6 +258,11 @@ NYC.prototype._transformFactory = function (cacheDir) {
 
     try {
       instrumented = instrumenter.instrumentSync(code, filename)
+
+      var lastSourceMap = instrumenter.lastSourceMap()
+      if (lastSourceMap) {
+        instrumented += '\n' + convertSourceMap.fromObject(lastSourceMap).toComment()
+      }
     } catch (e) {
       // don't fail external tests due to instrumentation bugs.
       console.warn('failed to instrument', filename, 'with error:', e.message)

--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -1,4 +1,4 @@
-function InstrumenterIstanbul (cwd) {
+function InstrumenterIstanbul (cwd, options) {
   var istanbul = InstrumenterIstanbul.istanbul()
 
   return istanbul.createInstrumenter({
@@ -6,7 +6,8 @@ function InstrumenterIstanbul (cwd) {
     coverageVariable: '__coverage__',
     embedSource: true,
     noCompact: false,
-    preserveComments: true
+    preserveComments: true,
+    produceSourceMap: options.produceSourceMap
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "yargs-parser": "^3.1.0"
   },
   "devDependencies": {
-    "@kpdecker/source-map-support": "^1.1.0",
     "any-path": "^1.3.0",
     "bundle-dependencies": "^1.0.2",
     "chai": "^3.0.0",
@@ -115,6 +114,7 @@
     "sanitize-filename": "^1.5.3",
     "sinon": "^1.15.3",
     "split-lines": "^1.0.0",
+    "source-map-support": "^0.4.6",
     "standard": "^8.0.0",
     "standard-version": "^2.4.0",
     "tap": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "yargs-parser": "^3.1.0"
   },
   "devDependencies": {
+    "@kpdecker/source-map-support": "^1.1.0",
     "any-path": "^1.3.0",
     "bundle-dependencies": "^1.0.2",
     "chai": "^3.0.0",
@@ -113,7 +114,6 @@
     "requirejs": "^2.3.0",
     "sanitize-filename": "^1.5.3",
     "sinon": "^1.15.3",
-    "source-map-support": "^0.4.2",
     "split-lines": "^1.0.0",
     "standard": "^8.0.0",
     "standard-version": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "istanbul-lib-source-maps": "^1.0.1",
     "istanbul-reports": "^1.0.0-alpha.8",
     "md5-hex": "^1.2.0",
+    "merge-source-map": "^1.0.2",
     "micromatch": "^2.3.11",
     "mkdirp": "^0.5.0",
     "pkg-up": "^1.0.0",

--- a/test/fixtures/stack-trace.js
+++ b/test/fixtures/stack-trace.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function blah() {
+  throw new Error('Blarrh')
+}
+
+var stack;
+try {
+  blah();
+} catch(err) {
+  stack = err.stack;
+}
+
+module.exports = function() {
+  return stack;
+}

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 
-require('source-map-support').install()
+require('@kpdecker/source-map-support').install({hookRequire: true})
 var _ = require('lodash')
 var ap = require('any-path')
 var configUtil = require('../../lib/config-util')
@@ -199,6 +199,26 @@ describe('nyc', function () {
 
         // and the hook should have been called
         hook.callCount.should.equal(1)
+      })
+    })
+
+    describe('produce source map', function () {
+      it('handles stack traces', function () {
+        var nyc = new NYC(configUtil.loadConfig())
+        nyc.reset()
+        nyc.wrap()
+
+        var check = require('../fixtures/stack-trace')
+        check().should.match(/stack-trace.js:4:/)
+      })
+
+      it('does not handle stack traces when disabled', function () {
+        var nyc = new NYC(configUtil.loadConfig(['--source-map=false']))
+        nyc.reset()
+        nyc.wrap()
+
+        var check = require('../fixtures/stack-trace')
+        check().should.match(/stack-trace.js:1:/)
       })
     })
 

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 
-require('@kpdecker/source-map-support').install({hookRequire: true})
+require('source-map-support').install({hookRequire: true})
 var _ = require('lodash')
 var ap = require('any-path')
 var configUtil = require('../../lib/config-util')


### PR DESCRIPTION
This allows the user to control the source map output post instrumentation.

Not fully straightforward right now, but when combined with a fork of source-map-support that has inline support (or placing the files in the proper location), end to end covered source maps can be achieved.

For runtime source-map-support, see https://github.com/evanw/node-source-map-support/pull/118. Will be forking to @kpdecker/source-map-support soon, since the canonical project appears to be dead.

Fix for #285 (When combined with the above)
