### PR TITLE
fix: add a feature which allows us to bust the cache when breaking changes are introduced

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,9 @@ try {
   ProcessInfo = require('./lib/process.js')
 }
 
-var CACHE_VERSION = '2'
+// bust cache whenever nyc is upgraded, this prevents
+// crashers caused by instrumentation updates.
+var CACHE_VERSION = require('./package.json').version
 
 /* istanbul ignore next */
 if (/index\.covered\.js$/.test(__filename)) {

--- a/index.js
+++ b/index.js
@@ -24,6 +24,7 @@ var ProcessInfo
 try {
   ProcessInfo = require('./lib/process.covered.js')
 } catch (e) {
+  /* istanbul ignore next */
   ProcessInfo = require('./lib/process.js')
 }
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,8 @@ try {
   ProcessInfo = require('./lib/process.js')
 }
 
+var CACHE_VERSION = '2'
+
 /* istanbul ignore next */
 if (/index\.covered\.js$/.test(__filename)) {
   require('./lib/self-coverage-helper')
@@ -83,13 +85,14 @@ function NYC (config) {
 
 NYC.prototype._createTransform = function (ext) {
   var _this = this
+
   return cachingTransform({
     salt: JSON.stringify({
       istanbul: require('istanbul-lib-coverage/package.json').version,
       nyc: require('./package.json').version
     }),
     hash: function (code, metadata, salt) {
-      var hash = md5hex([code, metadata.filename, salt])
+      var hash = md5hex([code, metadata.filename, salt]) + '_' + CACHE_VERSION
       _this.hashCache[metadata.filename] = hash
       return hash
     },


### PR DESCRIPTION
when we make potentially breaking changes to the cache, e.g.,

https://github.com/istanbuljs/istanbul-lib-instrument/pull/22

we should increment the cache version, forcing an invalidation so that folks don't see issues like #392 