### PR TITLE
chore: Remove 'coming soon' note for .nycrc file

### DIFF
--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -8,9 +8,9 @@ var Yargs = require('yargs/yargs')
 var Config = {}
 
 // load config from a cascade of sources:
-// * command line arguments.
-// * package.json.
-// * .nycrc (coming soon)
+// * command line arguments
+// * package.json
+// * .nycrc
 Config.loadConfig = function (argv, cwd) {
   cwd = cwd || process.env.NYC_CWD || process.cwd()
   var pkgPath = findUp.sync('package.json', {cwd: cwd})


### PR DESCRIPTION
Support for a .nycrc config file has been added.