### PR TITLE
chore: tell Greenkeeper to ignore find-up releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,5 +149,10 @@
     "test-exclude",
     "yargs",
     "yargs-parser"
-  ]
+  ],
+  "greenkeeper": {
+    "ignore": [
+      "find-up"
+    ]
+  }
 }


### PR DESCRIPTION
find-up@2 is not compatible with Node.js 0.10, which is our oldest supported Node.js version.

Follow-up to <https://github.com/istanbuljs/nyc/pull/399#issuecomment-248361632>.