### PR TITLE
feat: implement coverage details for process tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -413,7 +413,7 @@ function coverageFinder () {
 NYC.prototype._getCoverageMapFromAllCoverageFiles = function () {
   var map = libCoverage.createCoverageMap({})
 
-  this._loadReports().forEach(function (report) {
+  this.loadReports().forEach(function (report) {
     map.merge(report)
   })
 
@@ -439,7 +439,9 @@ NYC.prototype.report = function () {
 }
 
 NYC.prototype.showProcessTree = function () {
-  console.log(this._loadProcessInfoTree().render())
+  var processTree = ProcessInfo.buildProcessTree(this._loadProcessInfos())
+
+  console.log(processTree.render(this))
 }
 
 NYC.prototype.checkCoverage = function (thresholds) {
@@ -459,27 +461,6 @@ NYC.prototype.checkCoverage = function (thresholds) {
   if (/^v0\.(1[0-1]\.|[0-9]\.)/.test(process.version) && process.exitCode !== 0) process.exit(process.exitCode)
 }
 
-NYC.prototype._loadProcessInfoTree = function () {
-  var _this = this
-  var processTree = ProcessInfo.buildProcessTree(this._loadProcessInfos())
-
-  processTree.getCoverageMap(function (filenames, maps) {
-    var map = libCoverage.createCoverageMap({})
-
-    _this._loadReports(filenames).forEach(function (report) {
-      map.merge(report)
-    })
-
-    maps.forEach(function (otherMap) {
-      map.merge(otherMap)
-    })
-
-    return map
-  })
-
-  return processTree
-}
-
 NYC.prototype._loadProcessInfos = function () {
   var _this = this
   var files = fs.readdirSync(this.processInfoDirectory())
@@ -496,7 +477,7 @@ NYC.prototype._loadProcessInfos = function () {
   })
 }
 
-NYC.prototype._loadReports = function (filenames) {
+NYC.prototype.loadReports = function (filenames) {
   var _this = this
   var files = filenames || fs.readdirSync(this.tempDirectory())
 

--- a/index.js
+++ b/index.js
@@ -460,7 +460,24 @@ NYC.prototype.checkCoverage = function (thresholds) {
 }
 
 NYC.prototype._loadProcessInfoTree = function () {
-  return ProcessInfo.buildProcessTree(this._loadProcessInfos())
+  var _this = this
+  var processTree = ProcessInfo.buildProcessTree(this._loadProcessInfos())
+
+  processTree.getCoverageMap(function (filenames, maps) {
+    var map = libCoverage.createCoverageMap({})
+
+    _this._loadReports(filenames).forEach(function (report) {
+      map.merge(report)
+    })
+
+    maps.forEach(function (otherMap) {
+      map.merge(otherMap)
+    })
+
+    return map
+  })
+
+  return processTree
 }
 
 NYC.prototype._loadProcessInfos = function () {
@@ -479,9 +496,9 @@ NYC.prototype._loadProcessInfos = function () {
   })
 }
 
-NYC.prototype._loadReports = function () {
+NYC.prototype._loadReports = function (filenames) {
   var _this = this
-  var files = fs.readdirSync(this.tempDirectory())
+  var files = filenames || fs.readdirSync(this.tempDirectory())
 
   var cacheDir = _this.cacheDirectory
 

--- a/lib/process.js
+++ b/lib/process.js
@@ -14,6 +14,8 @@ function ProcessInfo (defaults) {
   this.coverageFilename = null
   this.nodes = [] // list of children, filled by buildProcessTree()
 
+  this._coverageMap = null
+
   for (var key in defaults) {
     this[key] = defaults[key]
   }
@@ -25,7 +27,11 @@ Object.defineProperty(ProcessInfo.prototype, 'label', {
       return this._label
     }
 
-    return this.argv.join(' ')
+    var covInfo = ''
+    if (this._coverageMap) {
+      covInfo = '\n  ' + this._coverageMap.getCoverageSummary().lines.pct + ' % Lines'
+    }
+    return this.argv.join(' ') + covInfo
   }
 })
 
@@ -55,6 +61,20 @@ ProcessInfo.buildProcessTree = function (infos) {
   })
 
   return treeRoot
+}
+
+ProcessInfo.prototype.getCoverageMap = function (merger) {
+  if (this._coverageMap) {
+    return this._coverageMap
+  }
+
+  var childMaps = this.nodes.map(function (child) {
+    return child.getCoverageMap(merger)
+  })
+
+  this._coverageMap = merger([this.coverageFilename], childMaps)
+
+  return this._coverageMap
 }
 
 ProcessInfo.prototype.render = function () {

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,5 +1,6 @@
 'use strict'
 var archy = require('archy')
+var libCoverage = require('istanbul-lib-coverage')
 
 function ProcessInfo (defaults) {
   defaults = defaults || {}
@@ -77,7 +78,21 @@ ProcessInfo.prototype.getCoverageMap = function (merger) {
   return this._coverageMap
 }
 
-ProcessInfo.prototype.render = function () {
+ProcessInfo.prototype.render = function (nyc) {
+  this.getCoverageMap(function (filenames, maps) {
+    var map = libCoverage.createCoverageMap({})
+
+    nyc.loadReports(filenames).forEach(function (report) {
+      map.merge(report)
+    })
+
+    maps.forEach(function (otherMap) {
+      map.merge(otherMap)
+    })
+
+    return map
+  })
+
   return archy(this)
 }
 

--- a/test/src/nyc-bin.js
+++ b/test/src/nyc-bin.js
@@ -580,14 +580,23 @@ describe('the nyc cli', function () {
         stdout.should.match(new RegExp(
           'nyc\n' +
           '└─┬.*selfspawn-fibonacci.js 5\n' +
+          '  │.* % Lines\n' +
           '  ├─┬.*selfspawn-fibonacci.js 4\n' +
+          '  │ │.* % Lines\n' +
           '  │ ├─┬.*selfspawn-fibonacci.js 3\n' +
+          '  │ │ │.* % Lines\n' +
           '  │ │ ├──.*selfspawn-fibonacci.js 2\n' +
+          '  │ │ │.* % Lines\n' +
           '  │ │ └──.*selfspawn-fibonacci.js 1\n' +
+          '  │ │    .* % Lines\n' +
           '  │ └──.*selfspawn-fibonacci.js 2\n' +
+          '  │    .* % Lines\n' +
           '  └─┬.*selfspawn-fibonacci.js 3\n' +
+          '    │.* % Lines\n' +
           '    ├──.*selfspawn-fibonacci.js 2\n' +
-          '    └──.*selfspawn-fibonacci.js 1\n'
+          '    │.* % Lines\n' +
+          '    └──.*selfspawn-fibonacci.js 1\n' +
+          '       .* % Lines\n'
         ))
         done()
       })

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -248,7 +248,7 @@ describe('nyc', function () {
       })
 
       proc.on('close', function () {
-        var reports = _.filter(nyc._loadReports(), function (report) {
+        var reports = _.filter(nyc.loadReports(), function (report) {
           return report[path.join(fixtures, signal + '.js')]
         })
         reports.length.should.equal(1)
@@ -271,7 +271,7 @@ describe('nyc', function () {
       nyc.wrap()
       nyc.reset()
 
-      var reports = _.filter(nyc._loadReports(), function (report) {
+      var reports = _.filter(nyc.loadReports(), function (report) {
         return report['./test/fixtures/not-loaded.js']
       })
       reports.length.should.equal(0)
@@ -308,7 +308,7 @@ describe('nyc', function () {
       nyc.addAllFiles()
 
       var notLoadedPath = path.join(fixtures, './not-loaded.js')
-      var reports = _.filter(nyc._loadReports(), function (report) {
+      var reports = _.filter(nyc.loadReports(), function (report) {
         return ap(report)[notLoadedPath]
       })
       var report = reports[0][notLoadedPath]
@@ -327,7 +327,7 @@ describe('nyc', function () {
 
       var notLoadedPath1 = path.join(cwd, './not-loaded.es6')
       var notLoadedPath2 = path.join(cwd, './not-loaded.js')
-      var reports = _.filter(nyc._loadReports(), function (report) {
+      var reports = _.filter(nyc.loadReports(), function (report) {
         var apr = ap(report)
         return apr[notLoadedPath1] || apr[notLoadedPath2]
       })
@@ -355,7 +355,7 @@ describe('nyc', function () {
       nyc.writeCoverageFile()
 
       var notLoadedPath = path.join(fixtures, './not-loaded.js')
-      var reports = _.filter(nyc._loadReports(), function (report) {
+      var reports = _.filter(nyc.loadReports(), function (report) {
         return report[notLoadedPath]
       })
       var report = reports[0][notLoadedPath]
@@ -379,7 +379,7 @@ describe('nyc', function () {
       nyc.addAllFiles()
 
       var needsTranspilePath = path.join(fixtures, './needs-transpile.js')
-      var reports = _.filter(nyc._loadReports(), function (report) {
+      var reports = _.filter(nyc.loadReports(), function (report) {
         return ap(report)[needsTranspilePath]
       })
       var report = reports[0][needsTranspilePath]
@@ -408,7 +408,7 @@ describe('nyc', function () {
     nyc.addAllFiles()
 
     var needsTranspilePath = path.join(fixtures, './needs-transpile.whatever')
-    var reports = _.filter(nyc._loadReports(), function (report) {
+    var reports = _.filter(nyc.loadReports(), function (report) {
       return ap(report)[needsTranspilePath]
     })
     var report = reports[0][needsTranspilePath]


### PR DESCRIPTION
Show line coverage for each subtree of the tree of spawned processes.

This is just a start, but while I definitely wanted to begin working in that direction as planned, I’m not too certain about how this is best implemented when it comes to visual display… In theory, a full per-file coverage table could be shown for each subtree, but that seems like overkill, so I’ve just implemented something small. Also, maybe printing this extra information should be optional/configurable, too?

What do you think?