### PR TITLE
Read initial data from pre-instrumented files in "noop" instrumenter

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ NYC.prototype.addAllFiles = function () {
     var coverage = coverageFinder()
     var lastCoverage = _this.instrumenter().lastFileCoverage()
     if (lastCoverage) {
-      filename = lastCoverage.data.path
+      filename = lastCoverage.path
     }
     if (lastCoverage && _this.exclude.shouldInstrument(filename)) {
       coverage[filename] = lastCoverage

--- a/index.js
+++ b/index.js
@@ -169,7 +169,7 @@ NYC.prototype.addAllFiles = function () {
     var coverage = coverageFinder()
     var lastCoverage = _this.instrumenter().lastFileCoverage()
     if (lastCoverage) {
-      filename = lastCoverage.data.path;
+      filename = lastCoverage.data.path
     }
     if (lastCoverage && _this.exclude.shouldInstrument(filename)) {
       coverage[filename] = lastCoverage

--- a/index.js
+++ b/index.js
@@ -84,6 +84,8 @@ function NYC (config) {
 
   this.processInfo = new ProcessInfo(config && config._processInfo)
   this.rootId = this.processInfo.root || this.generateUniqueID()
+  this.instrument = config.instrument
+  this.all = config.all
 }
 
 NYC.prototype._createTransform = function (ext) {
@@ -166,6 +168,9 @@ NYC.prototype.addAllFiles = function () {
     _this.addFile(filename)
     var coverage = coverageFinder()
     var lastCoverage = _this.instrumenter().lastFileCoverage()
+    if (lastCoverage) {
+      filename = lastCoverage.data.path;
+    }
     if (lastCoverage && _this.exclude.shouldInstrument(filename)) {
       coverage[filename] = lastCoverage
     }
@@ -233,7 +238,7 @@ NYC.prototype.walkAllFiles = function (dir, visitor) {
 }
 
 NYC.prototype._maybeInstrumentSource = function (code, filename, relFile) {
-  var instrument = this.exclude.shouldInstrument(filename, relFile)
+  var instrument = (!this.instrument && this.all) || this.exclude.shouldInstrument(filename, relFile)
   if (!instrument) {
     return null
   }

--- a/lib/instrumenters/noop.js
+++ b/lib/instrumenters/noop.js
@@ -1,10 +1,19 @@
+var FileCoverage = require('istanbul-lib-coverage').classes.FileCoverage
+var readInitialCoverage = require('istanbul-lib-instrument').readInitialCoverage
+
 function NOOP () {
   return {
     instrumentSync: function (code) {
+      var extracted = readInitialCoverage(code)
+      if (extracted) {
+        this.fileCoverage = new FileCoverage(extracted.coverageData)
+      } else {
+        this.fileCoverage = null
+      }
       return code
     },
     lastFileCoverage: function () {
-      return null
+      return this.fileCoverage
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "glob": "^7.0.6",
     "istanbul-lib-coverage": "^1.0.0",
     "istanbul-lib-hook": "^1.0.0-alpha.4",
-    "istanbul-lib-instrument": "^1.1.3",
+    "istanbul-lib-instrument": "^1.2.0",
     "istanbul-lib-report": "^1.0.0-alpha.3",
     "istanbul-lib-source-maps": "^1.0.2",
     "istanbul-reports": "^1.0.0-alpha.8",


### PR DESCRIPTION
This is part of my fix for using `--all` on externally instrumented files, as when using babel-plugin-istanbul (https://github.com/istanbuljs/babel-plugin-istanbul/issues/4). I laid out the idea for this part [here](https://github.com/istanbuljs/istanbul-lib-instrument/pull/28#issuecomment-254422567).

Requires istanbuljs/istanbul-lib-instrument#28 and babel/babel#4746 (update: now both released, in istanbul-lib-instrument v1.2.0 and Babel v6.18.0 respectively).

To see the results and/or test this yourself, see the repo I've put up at https://github.com/motiz88/nyc-all-demo.

Known problems/kludges:

* The code makes a special case in `_maybeInstrumentSource` for `!this.instrument && this.all`, in which case it will always go on to "instrument" the file (actually read the existing data in the `noop` instrumenter). This is because we can't know until we've read the file whether it is a transpiled version of a file we're interested in.
* Instrumenting/testing when `process.cwd()` is a symlink causes problems at the moment, such as covered files being reported twice with different paths: one with 0% coverage and one with the actual coverage.