### PR TITLE
feat: adds support for source-map production

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,12 @@ and a `text-lcov` coverage report.
 nyc --reporter=lcov --reporter=text-lcov npm test
 ```
 
-## Stack Traces
+## Accurate stack traces using source maps
 
-When `source-map` handling enabled, then the instrumented source files will
+When `produce-source-map` is set to true, then the instrumented source files will
 include inline source maps for the instrumenter transform. When combined with
 [source-map-support](https://github.com/evanw/node-source-map-support),
-stack traces for instrumented code should reflect the original lines.
-
-This is enabled by default, but may be disabled by `nyc --source-map=false`.
+stack traces for instrumented code will reflect their original lines.
 
 ## Support for custom require hooks (babel, webpack, etc.)
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ and a `text-lcov` coverage report.
 nyc --reporter=lcov --reporter=text-lcov npm test
 ```
 
+## Stack Traces
+
+When `source-map` handling enabled, then the instrumented source files will
+include inline source maps for the instrumenter transform. When combined with
+a supporting version of [source-map-support](https://github.com/evanw/node-source-map-support/pull/118)
+(currently published under `@kpdecker/source-map-support` while PR pending),
+stack traces for instrumented code should reflect the original lines.
+
+This is enabled by default, but may be disabled by `nyc --source-map=false`.
+
 ## Support for custom require hooks (babel, webpack, etc.)
 
 nyc supports custom require hooks like

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ nyc --reporter=lcov --reporter=text-lcov npm test
 
 When `source-map` handling enabled, then the instrumented source files will
 include inline source maps for the instrumenter transform. When combined with
-a supporting version of [source-map-support](https://github.com/evanw/node-source-map-support/pull/118)
-(currently published under `@kpdecker/source-map-support` while PR pending),
+[source-map-support](https://github.com/evanw/node-source-map-support),
 stack traces for instrumented code should reflect the original lines.
 
 This is enabled by default, but may be disabled by `nyc --source-map=false`.

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var rimraf = require('rimraf')
 var onExit = require('signal-exit')
 var resolveFrom = require('resolve-from')
 var convertSourceMap = require('convert-source-map')
+var mergeSourceMap = require('merge-source-map')
 var md5hex = require('md5-hex')
 var findCacheDir = require('find-cache-dir')
 var js = require('default-require-extensions/js')
@@ -264,19 +265,30 @@ NYC.prototype._transformFactory = function (cacheDir) {
 
   return function (code, metadata, hash) {
     var filename = metadata.filename
+    var sourceMap
 
-    if (_this._sourceMap) _this._handleSourceMap(cacheDir, code, hash, filename)
+    if (_this._sourceMap) {
+      sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename))
+
+      _this._handleSourceMap(cacheDir, code, hash, filename, sourceMap)
+    }
 
     try {
       instrumented = instrumenter.instrumentSync(code, filename)
 
       var lastSourceMap = instrumenter.lastSourceMap()
       if (lastSourceMap) {
+        if (sourceMap) {
+          lastSourceMap = mergeSourceMap(
+                sourceMap.toObject(),
+                lastSourceMap)
+        }
+
         instrumented += '\n' + convertSourceMap.fromObject(lastSourceMap).toComment()
       }
     } catch (e) {
       // don't fail external tests due to instrumentation bugs.
-      console.warn('failed to instrument', filename, 'with error:', e.message)
+      console.warn('failed to instrument', filename, 'with error:', e.stack)
       instrumented = code
     }
 
@@ -288,8 +300,7 @@ NYC.prototype._transformFactory = function (cacheDir) {
   }
 }
 
-NYC.prototype._handleSourceMap = function (cacheDir, code, hash, filename) {
-  var sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename))
+NYC.prototype._handleSourceMap = function (cacheDir, code, hash, filename, sourceMap) {
   if (sourceMap) {
     if (hash) {
       var mapPath = path.join(cacheDir, hash + '.map')

--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ function NYC (config) {
   this._instrumenterLib = require(config.instrumenter || './lib/instrumenters/istanbul')
   this._reportDir = config.reportDir || 'coverage'
   this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true
-  this._produceSourceMap = typeof config.produceSourceMap !== 'undefined' ? config.produceSourceMap : 'inline'
   this._showProcessTree = config.showProcessTree || false
   this.cwd = config.cwd || process.cwd()
 
@@ -131,7 +130,7 @@ NYC.prototype.instrumenter = function () {
 
 NYC.prototype._createInstrumenter = function () {
   return this._instrumenterLib(this.cwd, {
-    produceSourceMap: this._produceSourceMap
+    produceSourceMap: this._sourceMap ? 'inline' : ''
   })
 }
 

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -168,6 +168,11 @@ Config.buildYargs = function (cwd) {
       type: 'boolean',
       description: 'should nyc detect and handle source maps?'
     })
+    .option('produce-source-map', {
+      default: false,
+      type: 'boolean',
+      description: "should nyc's instrumenter produce source maps?"
+    })
     .option('instrument', {
       default: true,
       type: 'boolean',

--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -1,4 +1,4 @@
-function InstrumenterIstanbul (cwd) {
+function InstrumenterIstanbul (cwd, options) {
   var istanbul = InstrumenterIstanbul.istanbul()
 
   return istanbul.createInstrumenter({
@@ -6,7 +6,8 @@ function InstrumenterIstanbul (cwd) {
     coverageVariable: '__coverage__',
     embedSource: true,
     noCompact: false,
-    preserveComments: true
+    preserveComments: true,
+    produceSourceMap: options.produceSourceMap
   })
 }
 

--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -1,7 +1,11 @@
+'use strict'
+
+var convertSourceMap = require('convert-source-map')
+var mergeSourceMap = require('merge-source-map')
+
 function InstrumenterIstanbul (cwd, options) {
   var istanbul = InstrumenterIstanbul.istanbul()
-
-  return istanbul.createInstrumenter({
+  var instrumenter = istanbul.createInstrumenter({
     autoWrap: true,
     coverageVariable: '__coverage__',
     embedSource: true,
@@ -9,6 +13,31 @@ function InstrumenterIstanbul (cwd, options) {
     preserveComments: true,
     produceSourceMap: options.produceSourceMap
   })
+
+  return {
+    instrumentSync: function (code, filename, sourceMap) {
+      var instrumented = instrumenter.instrumentSync(code, filename)
+      // the instrumenter can optionally produce source maps,
+      // this is useful for features like remapping stack-traces.
+      // TODO: test source-map merging logic.
+      if (options.produceSourceMap) {
+        var lastSourceMap = instrumenter.lastSourceMap()
+        if (lastSourceMap) {
+          if (sourceMap) {
+            lastSourceMap = mergeSourceMap(
+              sourceMap.toObject(),
+              lastSourceMap
+            )
+          }
+          instrumented += '\n' + convertSourceMap.fromObject(lastSourceMap).toComment()
+        }
+      }
+      return instrumented
+    },
+    lastFileCoverage: function () {
+      return instrumenter.lastFileCoverage()
+    }
+  }
 }
 
 InstrumenterIstanbul.istanbul = function () {

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "istanbul-lib-source-maps",
     "istanbul-reports",
     "md5-hex",
+    "merge-source-map",
     "micromatch",
     "mkdirp",
     "resolve-from",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "istanbul-lib-source-maps": "^1.0.2",
     "istanbul-reports": "^1.0.0",
     "md5-hex": "^1.2.0",
+    "merge-source-map": "^1.0.2",
     "micromatch": "^2.3.11",
     "mkdirp": "^0.5.0",
     "resolve-from": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,6 @@
     "yargs-parser": "^4.0.2"
   },
   "devDependencies": {
-    "@kpdecker/source-map-support": "^1.1.0",
     "any-path": "^1.3.0",
     "bundle-dependencies": "^1.0.2",
     "chai": "^3.0.0",
@@ -114,6 +113,7 @@
     "sanitize-filename": "^1.5.3",
     "sinon": "^1.15.3",
     "split-lines": "^1.0.0",
+    "source-map-support": "^0.4.6",
     "standard": "^8.0.0",
     "standard-version": "^3.0.0",
     "tap": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "yargs-parser": "^4.0.2"
   },
   "devDependencies": {
+    "@kpdecker/source-map-support": "^1.1.0",
     "any-path": "^1.3.0",
     "bundle-dependencies": "^1.0.2",
     "chai": "^3.0.0",
@@ -112,7 +113,6 @@
     "requirejs": "^2.3.0",
     "sanitize-filename": "^1.5.3",
     "sinon": "^1.15.3",
-    "source-map-support": "^0.4.2",
     "split-lines": "^1.0.0",
     "standard": "^8.0.0",
     "standard-version": "^3.0.0",

--- a/test/fixtures/stack-trace.js
+++ b/test/fixtures/stack-trace.js
@@ -1,0 +1,16 @@
+'use strict';
+
+function blah() {
+  throw new Error('Blarrh')
+}
+
+var stack;
+try {
+  blah();
+} catch(err) {
+  stack = err.stack;
+}
+
+module.exports = function() {
+  return stack;
+}

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -204,7 +204,7 @@ describe('nyc', function () {
 
     describe('produce source map', function () {
       it('handles stack traces', function () {
-        var nyc = new NYC(configUtil.loadConfig())
+        var nyc = new NYC(configUtil.loadConfig('--produce-source-map'))
         nyc.reset()
         nyc.wrap()
 
@@ -213,13 +213,15 @@ describe('nyc', function () {
       })
 
       it('does not handle stack traces when disabled', function () {
-        var nyc = new NYC(configUtil.loadConfig(['--source-map=false']))
+        var nyc = new NYC(configUtil.loadConfig())
         nyc.reset()
         nyc.wrap()
 
         var check = require('../fixtures/stack-trace')
         check().should.match(/stack-trace.js:1:/)
       })
+
+      // TODO: add test for merge source-map logic.
     })
 
     describe('compile handlers for custom extensions are assigned', function () {

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 
-require('source-map-support').install()
+require('@kpdecker/source-map-support').install({hookRequire: true})
 var _ = require('lodash')
 var ap = require('any-path')
 var configUtil = require('../../lib/config-util')
@@ -199,6 +199,26 @@ describe('nyc', function () {
 
         // and the hook should have been called
         hook.callCount.should.equal(1)
+      })
+    })
+
+    describe('produce source map', function () {
+      it('handles stack traces', function () {
+        var nyc = new NYC(configUtil.loadConfig())
+        nyc.reset()
+        nyc.wrap()
+
+        var check = require('../fixtures/stack-trace')
+        check().should.match(/stack-trace.js:4:/)
+      })
+
+      it('does not handle stack traces when disabled', function () {
+        var nyc = new NYC(configUtil.loadConfig(['--source-map=false']))
+        nyc.reset()
+        nyc.wrap()
+
+        var check = require('../fixtures/stack-trace')
+        check().should.match(/stack-trace.js:1:/)
       })
     })
 

--- a/test/src/nyc-test.js
+++ b/test/src/nyc-test.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 
-require('@kpdecker/source-map-support').install({hookRequire: true})
+require('source-map-support').install({hookRequire: true})
 var _ = require('lodash')
 var ap = require('any-path')
 var configUtil = require('../../lib/config-util')


### PR DESCRIPTION
@kpdecker I had some refactoring on my mind, that I opted to tack onto your work so that we can get this landed -- rather than overly marking up #393.

I made a few very minor changes:

* I think that source-map production and the application of source maps, are different enough behavior that it's worth introducing the additional flag `--produce-source-map`; I also had some performance concerns, and think it's better that folks using `source-map-support` opt in.
* I've been trying to gradually pull more and more logic out of `index.js`, so that it's ultimately just calling a bunch of pretty easy to follow libraries and helpers. tldr; I pulled the source-map logic into the instrumenter.
* I added a couple `TODOs` around adding additional tests, and opened #438.

CC: @JaKXz would love to have you take one final look at this.

