### PR TITLE
feat: allow an alternate cache folder to be provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ function NYC (config) {
 
   this.reporter = arrify(config.reporter || 'text')
 
-  this.cacheDirectory = findCacheDir({name: 'nyc', cwd: this.cwd})
+  this.cacheDirectory = config.cacheDir || findCacheDir({name: 'nyc', cwd: this.cwd})
 
   this.enableCache = Boolean(this.cacheDirectory && (config.enableCache === true || process.env.NYC_CACHE === 'enable'))
 

--- a/test/src/nyc-bin.js
+++ b/test/src/nyc-bin.js
@@ -670,4 +670,23 @@ describe('the nyc cli', function () {
       })
     })
   })
+
+  it('allows an alternative cache folder to be specified', function (done) {
+    var args = [bin, '--cache-dir=./foo-cache', '--cache=true', process.execPath, './half-covered.js']
+
+    var proc = spawn(process.execPath, args, {
+      cwd: fixturesCLI,
+      env: env
+    })
+    proc.on('close', function (code) {
+      code.should.equal(0)
+      // we should have created ./foo-cache rather
+      // than the default ./node_modules/.cache.
+      fs.readdirSync(path.resolve(
+        fixturesCLI, './foo-cache'
+      )).length.should.equal(1)
+      rimraf.sync(path.resolve(fixturesCLI, 'foo-cache'))
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This is an advanced workaround I've put in place for some experiments with the npm CLI; I'm opting to not document the flag for the time being, as I'd like to keep the help terse.