### PR TITLE
feat: reporting watermarks

### DIFF
--- a/index.js
+++ b/index.js
@@ -433,7 +433,8 @@ NYC.prototype.report = function () {
   var tree
   var map = this._getCoverageMapFromAllCoverageFiles()
   var context = libReport.createContext({
-    dir: this._reportDir
+    dir: this._reportDir,
+    watermarks: this.config.watermarks
   })
 
   tree = libReport.summarizers.pkg(map)


### PR DESCRIPTION
Passes watermarks from the nyc config to `istanbul-lib-report`. This should allow custom watermarks for all reporters in `istanbul-reports` that use them. In the old `.istanbul.yml` the watermarks lived under a `reporting` key, so maybe this should be there too, but I read thru some of the other PRs about the new config and thought this might make more sense in the context of those discussions. Plus `reportDir` was already top level too.