### PR TITLE
chore(package): update spawn-wrap to 1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "resolve-from": "^2.0.0",
     "rimraf": "^2.5.4",
     "signal-exit": "^3.0.1",
-    "spawn-wrap": "^1.2.4",
+    "spawn-wrap": "^1.3.2",
     "test-exclude": "^3.3.0",
     "yargs": "^6.4.0",
     "yargs-parser": "^4.0.2"


### PR DESCRIPTION
This fixes the wrapping of custom node binaries