### PR TITLE
fix: upgrade spawn-wrap and istanbul-lib-instrument

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "glob": "^7.0.6",
     "istanbul-lib-coverage": "^1.0.0",
     "istanbul-lib-hook": "^1.0.0-alpha.4",
-    "istanbul-lib-instrument": "^1.3.0",
+    "istanbul-lib-instrument": "^1.3.1",
     "istanbul-lib-report": "^1.0.0-alpha.3",
     "istanbul-lib-source-maps": "^1.1.0",
     "istanbul-reports": "^1.0.0",
@@ -95,7 +95,7 @@
     "resolve-from": "^2.0.0",
     "rimraf": "^2.5.4",
     "signal-exit": "^3.0.1",
-    "spawn-wrap": "^1.2.4",
+    "spawn-wrap": "^1.3.4",
     "test-exclude": "^3.3.0",
     "yargs": "^6.4.0",
     "yargs-parser": "^4.0.2"


### PR DESCRIPTION
new spawn-wrap should address @TheAlphaNerd's issues with CITGM, and pulls in @wyze's fix for function names in istanbul-lib-instrument.