### PR TITLE
Fix use of --all when instrumentation is disabled

### DIFF
--- a/lib/instrumenters/noop.js
+++ b/lib/instrumenters/noop.js
@@ -3,12 +3,12 @@ var readInitialCoverage = require('istanbul-lib-instrument').readInitialCoverage
 
 function NOOP () {
   return {
-    instrumentSync: function (code) {
+    instrumentSync: function (code, filename) {
       var extracted = readInitialCoverage(code)
       if (extracted) {
         this.fileCoverage = new FileCoverage(extracted.coverageData)
       } else {
-        this.fileCoverage = null
+        this.fileCoverage = new FileCoverage(filename)
       }
       return code
     },


### PR DESCRIPTION
This allows the use of `--all` with `babel-transform-istanbul`, for instance.