### PR TITLE
Fix check-coverage with custom options

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -91,7 +91,7 @@ function report (argv) {
 function checkCoverage (argv, cb) {
   process.env.NYC_CWD = process.cwd()
 
-  ;(new NYC()).checkCoverage({
+  ;(new NYC(argv)).checkCoverage({
     lines: argv.lines,
     functions: argv.functions,
     branches: argv.branches,


### PR DESCRIPTION
Specifically, if the temp directory is configured, this needs to be configured on the NYC instance for both the command line action `check-coverage` as well as the `--check-coverage` flag passed when executing tests.