### PR TITLE
Allow eager instantiation of instrumenter

### DIFF
--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -131,6 +131,11 @@ Config.buildYargs = function (cwd) {
       default: [],
       describe: 'a list of additional modules that nyc should attempt to require in its subprocess, e.g., babel-register, babel-polyfill.'
     })
+    .option('eager', {
+      default: false,
+      type: 'boolean',
+      describe: 'instantiate the instrumenter at startup (see https://git.io/vMKZ9)'
+    })
     .option('cache', {
       alias: 'c',
       default: true,


### PR DESCRIPTION
This change adds an `--eager` option to nyc which forces instantiation
of the instrumentation library prior to walking any of the files.

Addresses #491
