### PR TITLE
feat: allow user to turn on babel cache

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-// the babel cache does not play nicely with nyc.
-process.env.BABEL_DISABLE_CACHE = '1'
-
 var configUtil = require('../lib/config-util')
 var foreground = require('foreground-child')
 var NYC
@@ -24,6 +21,11 @@ var yargs = configUtil.decorateYargs(configUtil.buildYargs())
 var instrumenterArgs = processArgs.hideInstrumenteeArgs()
 var argv = yargs.parse(instrumenterArgs)
 var config = configUtil.loadConfig(instrumenterArgs)
+
+if (config['babel-cache'] === false) {
+  // the babel cache in few cases does not play nicely with nyc.
+  process.env.BABEL_DISABLE_CACHE = 1
+}
 
 if (argv._[0] === 'report') {
   // run a report.
@@ -50,8 +52,8 @@ if (argv._[0] === 'report') {
     NYC_CONFIG: JSON.stringify(config),
     NYC_CWD: process.cwd(),
     NYC_ROOT_ID: nyc.rootId,
-    BABEL_DISABLE_CACHE: 1,
-    NYC_INSTRUMENTER: config.instrumenter
+    NYC_INSTRUMENTER: config.instrumenter,
+    BABEL_DISABLE_CACHE: process.env.BABEL_DISABLE_CACHE
   }
   sw([wrapper], env)
 

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -142,6 +142,11 @@ Config.buildYargs = function (cwd) {
       type: 'boolean',
       describe: 'cache instrumentation results for improved performance'
     })
+    .option('babel-cache', {
+      default: false,
+      type: 'boolean',
+      describe: 'cache babel transpilation results for improved performance'
+    })
     .option('extension', {
       alias: 'e',
       default: [],


### PR DESCRIPTION
Hey! Recently we have switched to nyc and I was a bit surprised when I saw that babel cache is turned off. Then I've found this PR https://github.com/istanbuljs/nyc/pull/303. Unfortunately it does not explain the reason why nyc works sometimes incorrect when babel cache is turned on. 

I believe that it all depend on the rest of the test stack. I've made a couple tests and there was 50% of speed improvement for my project, so this gave me an idea. 

Why not to allow babel cache to be optional?
