### PR TITLE
feat: allow babel cache to be enabled

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -22,11 +22,6 @@ var instrumenterArgs = processArgs.hideInstrumenteeArgs()
 var argv = yargs.parse(instrumenterArgs)
 var config = configUtil.loadConfig(instrumenterArgs)
 
-if (config['babel-cache'] === false) {
-  // the babel cache in few cases does not play nicely with nyc.
-  process.env.BABEL_DISABLE_CACHE = 1
-}
-
 if (argv._[0] === 'report') {
   // run a report.
   process.env.NYC_CWD = process.cwd()
@@ -52,9 +47,15 @@ if (argv._[0] === 'report') {
     NYC_CONFIG: JSON.stringify(config),
     NYC_CWD: process.cwd(),
     NYC_ROOT_ID: nyc.rootId,
-    NYC_INSTRUMENTER: config.instrumenter,
-    BABEL_DISABLE_CACHE: process.env.BABEL_DISABLE_CACHE
+    NYC_INSTRUMENTER: config.instrumenter
   }
+
+  if (config['babel-cache'] === false) {
+    // babel's cache interferes with some configurations, so is
+    // disabled by default. opt in by setting babel-cache=true.
+    env.BABEL_DISABLE_CACHE = process.env.BABEL_DISABLE_CACHE = '1'
+  }
+
   sw([wrapper], env)
 
   // Both running the test script invocation and the check-coverage run may

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-// the babel cache does not play nicely with nyc.
-process.env.BABEL_DISABLE_CACHE = '1'
-
 var configUtil = require('../lib/config-util')
 var foreground = require('foreground-child')
 var NYC
@@ -24,6 +21,11 @@ var yargs = configUtil.decorateYargs(configUtil.buildYargs())
 var instrumenterArgs = processArgs.hideInstrumenteeArgs()
 var argv = yargs.parse(instrumenterArgs)
 var config = configUtil.loadConfig(instrumenterArgs)
+
+if (config['babel-cache'] === false) {
+  // the babel cache in few cases does not play nicely with nyc.
+  process.env.BABEL_DISABLE_CACHE = 1
+}
 
 if (argv._[0] === 'report') {
   // run a report.
@@ -50,8 +52,8 @@ if (argv._[0] === 'report') {
     NYC_CONFIG: JSON.stringify(config),
     NYC_CWD: process.cwd(),
     NYC_ROOT_ID: nyc.rootId,
-    BABEL_DISABLE_CACHE: 1,
-    NYC_INSTRUMENTER: config.instrumenter
+    NYC_INSTRUMENTER: config.instrumenter,
+    BABEL_DISABLE_CACHE: process.env.BABEL_DISABLE_CACHE
   }
   sw([wrapper], env)
 

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -142,6 +142,11 @@ Config.buildYargs = function (cwd) {
       type: 'boolean',
       describe: 'cache instrumentation results for improved performance'
     })
+    .option('babel-cache', {
+      default: false,
+      type: 'boolean',
+      describe: 'cache babel transpilation results for improved performance'
+    })
     .option('extension', {
       alias: 'e',
       default: [],


### PR DESCRIPTION
Allow the babel cache to be disabled, thanks for the patch @Arturszott.

In this pull I make one tiny tweak, the environment variable is now simply not set if you set `babel-cache=true`.