### PR TITLE
feat: upgrade to version of yargs that introduces extends feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "signal-exit": "^3.0.1",
     "spawn-wrap": "1.2.4",
     "test-exclude": "^4.0.0",
-    "yargs": "^6.6.0",
+    "yargs": "^7.0.0-alpha.3",
     "yargs-parser": "^4.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
config files can now be extended using a key `extends`, which points to a configuration file to inherit from.

fixes #503