### PR TITLE
feat: allow NYC_NO_INSTRUMENT to be provided, to disable instrumentation

### DIFF
--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -17,6 +17,6 @@ config._processInfo = {
   root: process.env.NYC_ROOT_ID
 }
 
-;(new NYC(config)).wrap()
+if (!process.env.NYC_NO_INSTRUMENT) ;(new NYC(config)).wrap()
 
 sw.runMain()


### PR DESCRIPTION
I'm working in istanbuljs' monorepo, and would like to be able to turn off instrumentation for just one of the repos.