### PR TITLE
Add possibility to filter during report generation

### DIFF
--- a/index.js
+++ b/index.js
@@ -426,11 +426,13 @@ function coverageFinder () {
 }
 
 NYC.prototype._getCoverageMapFromAllCoverageFiles = function () {
+  var _this = this;
   var map = libCoverage.createCoverageMap({})
 
   this.loadReports().forEach(function (report) {
     map.merge(report)
   })
+  map.filter(function(filename) { return _this.exclude.shouldReport(filename) })
 
   return map
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "find-up": "^1.1.2",
     "foreground-child": "^1.5.3",
     "glob": "^7.0.6",
-    "istanbul-lib-coverage": "^1.0.1",
+    "istanbul-lib-coverage": "schutm/istanbul-lib-coverage",
     "istanbul-lib-hook": "^1.0.0",
     "istanbul-lib-instrument": "^1.4.2",
     "istanbul-lib-report": "^1.0.0-alpha.3",
@@ -96,7 +96,7 @@
     "rimraf": "^2.5.4",
     "signal-exit": "^3.0.1",
     "spawn-wrap": "1.2.4",
-    "test-exclude": "^4.0.0",
+    "test-exclude": "schutm/test-exclude",
     "yargs": "^6.6.0",
     "yargs-parser": "^4.0.2"
   },


### PR DESCRIPTION
Have the --exclude and --include also work when the report command is being used and not only during instrumentation.

E.G. Instrument and write to the cache directory using `nyc --silent ava` and later create specific report using e.g. `nyc report --include '**/bin/*.js` (ignoring all other files located in e.g. **/lib/**

In my specific this is required because my files are precompiled using rollup. This includes also files from external libraries in the resulting files. These files get tested (other the tests will fail due to import statements). However nyc will only exclude files actually present. It doesn't perform this action based on the  sourcemaps. Therefor I filter the report itself.