### PR TITLE
Test node 6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - 6
   - 4
   - 5
   - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ language: node_js
 node_js:
   - 6
   - 4
-  - 5
   - "0.10"
-  - "0.12"
   - "stable"
 
 before_install:


### PR DESCRIPTION
node@6 is the current LTS. "stable" is node@7

Might want to consider dropping 0.10, 0.12 and 5 as they are EOL, but as a testing tool, maybe not? 😄 