### PR TITLE
feat: add support for --no-clean, to disable deleting raw coverage output

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -38,8 +38,7 @@ if (argv._[0] === 'report') {
   else config.instrumenter = './lib/instrumenters/istanbul'
 
   var nyc = (new NYC(config))
-  nyc.reset()
-
+  if (config.clean) nyc.reset()
   if (config.all) nyc.addAllFiles()
 
   var env = {

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -219,6 +219,17 @@ Config.buildYargs = function (cwd) {
       type: 'boolean',
       global: false
     })
+    .option('clean', {
+      describe: 'should the .nyc_output folder be deleted before executing tests',
+      default: true,
+      type: 'boolean',
+      global: false
+    })
+    .option('temp-directory', {
+      describe: 'directory to output raw coverage data in',
+      default: './.nyc_output',
+      global: false
+    })
     .pkgConf('nyc', cwd || process.cwd())
     .example('$0 npm test', 'instrument your tests with coverage')
     .example('$0 --require babel-core/register npm test', 'instrument your tests with coverage and babel')

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -64,7 +64,7 @@ Config.buildYargs = function (cwd) {
           default: 'coverage'
         })
         .option('temp-directory', {
-          describe: 'directory from which coverage JSON files are read',
+          describe: 'directory to read raw coverage information from',
           default: './.nyc_output'
         })
         .option('show-process-tree', {
@@ -220,13 +220,13 @@ Config.buildYargs = function (cwd) {
       global: false
     })
     .option('clean', {
-      describe: 'should the .nyc_output folder be deleted before executing tests',
+      describe: 'should the .nyc_output folder be cleaned before executing tests',
       default: true,
       type: 'boolean',
       global: false
     })
     .option('temp-directory', {
-      describe: 'directory to output raw coverage data in',
+      describe: 'directory to output raw coverage information in',
       default: './.nyc_output',
       global: false
     })

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -226,7 +226,7 @@ Config.buildYargs = function (cwd) {
       global: false
     })
     .option('temp-directory', {
-      describe: 'directory to output raw coverage information in',
+      describe: 'directory to output raw coverage information to',
       default: './.nyc_output',
       global: false
     })

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "node ./build-tests",
     "instrument": "node ./build-self-coverage.js",
     "test-integration": "tap -t120 --no-cov -b ./test/build/*.js && mocha --timeout=15000 ./test/src/nyc-bin.js",
-    "test-mocha": "node ./bin/nyc --silent --temp-directory=./.self_coverage mocha ./test/nyc.js ./test/process-args.js",
+    "test-mocha": "node ./bin/nyc --no-clean --silent --temp-directory=./.self_coverage mocha ./test/nyc.js ./test/process-args.js",
     "report": "node ./bin/nyc  --temp-directory ./.self_coverage/ -r text -r lcov report",
     "release": "standard-version"
   },


### PR DESCRIPTION
This pull request is a follow on to #556, which starts to switch some of our non-integration tests over to mocha (it was driving me bonkers not having --grep functionality in our slow suites).

@addaleax since nyc's own test suite now requires merging multiple test runs into a single coverage report, I revisited https://github.com/istanbuljs/nyc/issues/515

The approach now outputs both the tap integration tests, and the mocha tests to the same temporary folder, and runs report once all tests have run.

Once this is landed, can we close out #515? 