### PR TITLE
fix: we should not create a cache folder if cache is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -327,7 +327,7 @@ NYC.prototype.clearCache = function () {
 
 NYC.prototype.createTempDirectory = function () {
   mkdirp.sync(this.tempDirectory())
-  mkdirp.sync(this.cacheDirectory)
+  if (this.cache) mkdirp.sync(this.cacheDirectory)
 
   if (this._showProcessTree) {
     mkdirp.sync(this.processInfoDirectory())

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rimraf ./.nyc_output ./node_modules/.cache ./.self_coverage ./test/fixtures/.nyc_output ./test/fixtures/node_modules/.cache *covered.js ./lib/*covered.js",
     "build": "node ./build-tests",
     "instrument": "node ./build-self-coverage.js",
-    "test-integration": "tap -t120 --no-cov -b ./test/build/*.js && mocha --timeout=15000 ./test/src/nyc-bin.js",
+    "test-integration": "tap -t120 --no-cov -b ./test/build/*.js && mocha --timeout=15000 ./test/nyc-bin.js",
     "test-mocha": "node ./bin/nyc --no-clean --silent --temp-directory=./.self_coverage mocha ./test/nyc.js ./test/process-args.js",
     "report": "node ./bin/nyc  --temp-directory ./.self_coverage/ -r text -r lcov report",
     "release": "standard-version"

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -2,10 +2,10 @@
 
 var _ = require('lodash')
 var path = require('path')
-var bin = path.resolve(__dirname, '../../bin/nyc')
-var fixturesCLI = path.resolve(__dirname, '../fixtures/cli')
+var bin = path.resolve(__dirname, '../bin/nyc')
+var fixturesCLI = path.resolve(__dirname, './fixtures/cli')
 var fakebin = path.resolve(fixturesCLI, 'fakebin')
-var fixturesHooks = path.resolve(__dirname, '../fixtures/hooks')
+var fixturesHooks = path.resolve(__dirname, './fixtures/hooks')
 var fs = require('fs')
 var glob = require('glob')
 var isWindows = require('is-windows')()
@@ -685,6 +685,24 @@ describe('the nyc cli', function () {
         fixturesCLI, './foo-cache'
       )).length.should.equal(1)
       rimraf.sync(path.resolve(fixturesCLI, 'foo-cache'))
+      done()
+    })
+  })
+
+  // see: https://github.com/istanbuljs/nyc/issues/563
+  it('does not create .cache folder if cache is "false"', function (done) {
+    var args = [bin, '--cache=false', process.execPath, './index.js']
+
+    var proc = spawn(process.execPath, args, {
+      cwd: process.cwd(),
+      env: env
+    })
+
+    rimraf.sync('./node_modules/.cache')
+
+    proc.on('close', function (code) {
+      code.should.equal(0)
+      fs.existsSync('./node_modules/.cache').should.equal(false)
       done()
     })
   })

--- a/test/nyc.js
+++ b/test/nyc.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 
 const NYC = require('../')
+
 require('chai').should()
 
 describe('NYC', function () {


### PR DESCRIPTION
fixes #563, don't create a `.cache` folder if `--cache=false`.