### PR TITLE
Allow .nycrc.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 6
   - 4
-  - "0.10"
   - "stable"
 
 before_install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@ environment:
   matrix:
     - nodejs_version: '6' # stable
     - nodejs_version: '4' # LTS
-    - nodejs_version: '0.12'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm cache clear

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -14,7 +14,7 @@ var Config = {}
 Config.loadConfig = function (argv, cwd) {
   cwd = cwd || process.env.NYC_CWD || process.cwd()
   var pkgPath = findUp.sync('package.json', {cwd: cwd})
-  var rcPath = findUp.sync(['.nycrc', '.nycrc.json'], {cwd: cwd})
+  var rcPath = findUp.sync('.nycrc', {cwd: cwd}) || findUp.sync('.nycrc.json', {cwd: cwd})
   var rcConfig = null
 
   if (rcPath) {

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -14,7 +14,7 @@ var Config = {}
 Config.loadConfig = function (argv, cwd) {
   cwd = cwd || process.env.NYC_CWD || process.cwd()
   var pkgPath = findUp.sync('package.json', {cwd: cwd})
-  var rcPath = findUp.sync('.nycrc', {cwd: cwd})
+  var rcPath = findUp.sync(['.nycrc', '.nycrc.json'], {cwd: cwd})
   var rcConfig = null
 
   if (rcPath) {

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -14,7 +14,7 @@ var Config = {}
 Config.loadConfig = function (argv, cwd) {
   cwd = cwd || process.env.NYC_CWD || process.cwd()
   var pkgPath = findUp.sync('package.json', {cwd: cwd})
-  var rcPath = findUp.sync('.nycrc', {cwd: cwd}) || findUp.sync('.nycrc.json', {cwd: cwd})
+  var rcPath = findUp.sync(['.nycrc', '.nycrc.json'], {cwd: cwd})
   var rcConfig = null
 
   if (rcPath) {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "debug-log": "^1.0.1",
     "default-require-extensions": "^1.0.0",
     "find-cache-dir": "^0.1.1",
-    "find-up": "^2.1.0",
+    "find-up": "^1.1.2",
     "foreground-child": "^1.5.3",
     "glob": "^7.0.6",
     "istanbul-lib-coverage": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "debug-log": "^1.0.1",
     "default-require-extensions": "^1.0.0",
     "find-cache-dir": "^0.1.1",
-    "find-up": "^1.1.2",
+    "find-up": "^2.1.0",
     "foreground-child": "^1.5.3",
     "glob": "^7.0.6",
     "istanbul-lib-coverage": "^1.1.0",


### PR DESCRIPTION
Addresses #579 by updating `find-up`. Tests pass after the update, which allows for an array of filenames to be passed into `sync`. AFAICT there are no breaking changes in the way `findUp` is being used – `sync` will accept a string or an array, and there are only two calls to `findUp.sync` that I can find in the codebase.

I looked into making a test for this, and I'm happy to take a crack at it, but it seemed like duplicating a lot of stuff (fixtures, setup, etc) for little gain.

Honestly, I don't really know how important or useful this PR is, but it does seem like other similar tools I use (ESLint, e.g.) allow for file extensions on their rc files, and it is minutely helpful to my own development workflow.