### PR TITLE
Fix #91

### DIFF
--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -11,7 +11,8 @@ function InstrumenterIstanbul (cwd, options) {
     embedSource: true,
     noCompact: false,
     preserveComments: true,
-    produceSourceMap: options.produceSourceMap
+    produceSourceMap: options.produceSourceMap,
+    esModules: true
   })
 
   return {


### PR DESCRIPTION
This change enables ES6 modules to be picked up by --all, for correct code coverage metrics.