### PR TITLE
spawn-wrap@1.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test-integration": "tap -t120 --no-cov -b ./test/build/*.js && mocha --timeout=15000 ./test/nyc-bin.js",
     "test-mocha": "node ./bin/nyc --no-clean --silent --temp-directory=./.self_coverage mocha ./test/nyc.js ./test/process-args.js",
     "report": "node ./bin/nyc  --temp-directory ./.self_coverage/ -r text -r lcov report",
-    "prerelease": "cp node_modules/signal-exit/signals.js node_modules/spawn-wrap/node_modules/signal-exit/signals.js",
     "release": "standard-version"
   },
   "bin": {
@@ -97,7 +96,7 @@
     "resolve-from": "^2.0.0",
     "rimraf": "^2.5.4",
     "signal-exit": "^3.0.1",
-    "spawn-wrap": "1.2.4",
+    "spawn-wrap": "^1.3.6",
     "test-exclude": "^4.1.1",
     "yargs": "^8.0.1",
     "yargs-parser": "^5.0.0"


### PR DESCRIPTION
Bump the dependency on spawn-wrap, now that https://github.com/tapjs/spawn-wrap/issues/44 is fixed.