### PR TITLE
fix: accept npm v5 package version

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const CACHE_VERSION = require('../package.json').version
 const md5hex = require('md5-hex')
 const salt = JSON.stringify({
@@ -6,7 +7,7 @@ const salt = JSON.stringify({
 })
 
 function Hash (code, filename) {
-  return md5hex([code, filename, salt]) + '_' + CACHE_VERSION
+  return md5hex([code, filename, salt]) + '_' + path.basename(CACHE_VERSION)
 }
 
 Hash.salt = salt

--- a/test/fixtures/conf-empty/package.json
+++ b/test/fixtures/conf-empty/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc",
-  "version": "1.1.1",
+  "version": "https://registry.npmjs.org/nyc/-/nyc-1.1.1.tgz",
   "description": "forking code-coverage using istanbul.",
   "main": "index.js"
 }

--- a/test/fixtures/conf-multiple-extensions/package.json
+++ b/test/fixtures/conf-multiple-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc",
-  "version": "1.1.1",
+  "version": "https://registry.npmjs.org/nyc/-/nyc-1.1.1.tgz",
   "description": "forking code-coverage using istanbul.",
   "main": "index.js",
   "bin": {

--- a/test/fixtures/hooks/package.json
+++ b/test/fixtures/hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hooktest",
-  "version": "1.1.1",
+  "version": "https://registry.npmjs.org/nyc/-/nyc-1.1.1.tgz",
   "description": "AMD/ requirejs test project",
   "main": "index.js",
   "dependencies": {

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc",
-  "version": "1.1.1",
+  "version": "https://registry.npmjs.org/nyc/-/nyc-1.1.1.tgz",
   "description": "forking code-coverage using istanbul.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
npm v5 transforms the version field from the simple number to an URL of
the tgz file in the package.json when installing nyc as a dependency.
The version is appended to the hash for cache comparison which is also
used to create a cache directory on the filesystem. The URL may include
illegal character and the creation of the file fails.

Fixes https://github.com/istanbuljs/nyc/issues/615