### PR TITLE
fix: upgrade to spawn-wrap version that works with babel-register

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "resolve-from": "^2.0.0",
     "rimraf": "^2.5.4",
     "signal-exit": "^3.0.1",
-    "spawn-wrap": "^1.3.6",
+    "spawn-wrap": "^1.3.7",
     "test-exclude": "^4.1.1",
     "yargs": "^8.0.1",
     "yargs-parser": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "glob": "^7.0.6",
     "istanbul-lib-coverage": "^1.1.1",
     "istanbul-lib-hook": "^1.0.7",
-    "istanbul-lib-instrument": "^1.7.2",
+    "istanbul-lib-instrument": "^1.7.3",
     "istanbul-lib-report": "^1.1.1",
     "istanbul-lib-source-maps": "^1.2.1",
     "istanbul-reports": "^1.1.1",


### PR DESCRIPTION
see: https://github.com/istanbuljs/nyc/issues/599