### PR TITLE
Add support for --cwd (#542)

### DIFF
--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -41,7 +41,6 @@ Config.loadConfig = function (argv, cwd) {
   config.extension = arrify(config.extension)
   config.exclude = arrify(config.exclude)
   config.include = arrify(config.include)
-  config.cwd = cwd
 
   return config
 }
@@ -130,6 +129,10 @@ Config.buildYargs = function (cwd) {
       alias: 'n',
       default: [],
       describe: 'a list of specific files that should be covered, glob patterns are supported',
+      global: false
+    })
+    .option('cwd', {
+      describe: 'working directory to lookup for files',
       global: false
     })
     .option('require', {

--- a/test/src/nyc-tap.js
+++ b/test/src/nyc-tap.js
@@ -61,6 +61,11 @@ describe('nyc', function () {
       var nyc = new NYC(configUtil.loadConfig([], __dirname))
       nyc.cwd.should.eql(path.join(__dirname, '../..'))
     })
+
+    it('uses --cwd for cwd if it is set (highest priority and no look upwards for package.json) ', function () {
+      var nyc = new NYC(configUtil.loadConfig(['--cwd', __dirname], __dirname))
+      nyc.cwd.should.eql(__dirname)
+    })
   })
 
   describe('config', function () {


### PR DESCRIPTION
I added support for --root option
I found out that the `cwd` option does exactly what the --root is supposed to do except:

 - the NYC_CWD environment has no documentation
 - the implicit lookup for upward package.json is not something I would expect

So I added a --root option that simply force cwd to be what I tell it to be.