### PR TITLE
Add possibility to filter coveragemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -407,12 +407,16 @@ function coverageFinder () {
 }
 
 NYC.prototype._getCoverageMapFromAllCoverageFiles = function () {
+  var _this = this
   var map = libCoverage.createCoverageMap({})
 
   this.loadReports().forEach(function (report) {
     map.merge(report)
   })
   map.data = this.sourceMaps.remapCoverage(map.data)
+  map.filter(function (filename) {
+    return _this.exclude.shouldInstrument(filename)
+  })
   return map
 }
 


### PR DESCRIPTION
As dicussed in https://github.com/istanbuljs/istanbuljs/pull/24

I found some time to recreate the implementation of this using sourcemaps. The sourcemaps made it way easier and it looks nicer as well now!

To reiterate why I made this: I've a 'non-standard' setup, where I build my distribution-packages outside of the source folder. I do this because I write mainly ES6 code, and distribution-packages need to be plain old JavaScript. In addition because AVA is perfectly able to run ES6 tests, but not able to test ES6 modules I've to transpile my ES6 code (using rollup and babel/bublé) to plain JavaScript. The resulting transpiled file will also include all libraries being imported.

In addition you can use this feature to make more specific reports. Instrument once, and split your reporting over different folders, or outputs. E.g. in the mono-repo have a HTML-report per library.