### PR TITLE
Typescript code coverage with "all": true flag reports incorrect missing coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/build/
 *.covered.js
 needs-transpile.js
 package-lock.json
+.idea

--- a/test/fixtures/typescript-all/.gitignore
+++ b/test/fixtures/typescript-all/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/test/fixtures/typescript-all/package.json
+++ b/test/fixtures/typescript-all/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "typescript-all",
+  "version": "0.0.0-unofficial",
+  "description": "Test fixture for nyc with typescript with all=true",
+  "license": "MIT",
+  "devDependencies": {
+    "cross-env": "5.0.5",
+    "nyc": "11.1.0",
+    "ts-node": "3.3.0",
+    "typescript": "2.4.2"
+  },
+  "scripts": {
+    "coverage": "cross-env TS_NODE_FAST=true nyc --check-coverage -- node test/test-framework",
+    "coverage-without-all": "cross-env TS_NODE_FAST=true nyc --check-coverage --no-all -- node test/test-framework"
+  },
+  "nyc": {
+    "include": [
+      "src/**/*.ts"
+    ],
+    "exclude": [
+      "**/*.d.ts"
+    ],
+    "extension": [
+      ".ts"
+    ],
+    "reporter": [
+      "lcov",
+      "html",
+      "text-summary"
+    ],
+    "require": "ts-node/register",
+    "cache": true,
+    "temp-directory": "./build/nyc/cache",
+    "all": true,
+    "check-coverage": false,
+    "report-dir": "./build/coverage",
+    "es-module": false,
+    "lines": 100,
+    "statements": 100,
+    "functions": 100,
+    "branches": 100,
+    "watermarks": {
+      "lines": [
+        75,
+        100
+      ],
+      "functions": [
+        75,
+        100
+      ],
+      "branches": [
+        75,
+        100
+      ],
+      "statements": [
+        75,
+        100
+      ]
+    }
+  }
+}

--- a/test/fixtures/typescript-all/src/distance.ts
+++ b/test/fixtures/typescript-all/src/distance.ts
@@ -1,0 +1,6 @@
+import { abs, sqr } from './utils';
+import { Point } from './point';
+
+export let distance = (point1: Point, point2: Point): number => {
+  return Math.sqrt(sqr(abs(point1.x - point2.x)) + sqr(abs(point1.y - point2.y)));
+};

--- a/test/fixtures/typescript-all/src/point.ts
+++ b/test/fixtures/typescript-all/src/point.ts
@@ -1,0 +1,4 @@
+export interface Point {
+  x: number;
+  y: number;
+}

--- a/test/fixtures/typescript-all/src/utils.ts
+++ b/test/fixtures/typescript-all/src/utils.ts
@@ -1,0 +1,10 @@
+export let abs = (x: number) => {
+  if (x < 0) {
+    return -x;
+  } else {
+    return x;
+  }
+};
+
+export let sqr = (x: number) => x * x;
+

--- a/test/fixtures/typescript-all/test/distance-tests.ts
+++ b/test/fixtures/typescript-all/test/distance-tests.ts
@@ -1,0 +1,16 @@
+import { Point } from '../src/point';
+import { distance } from '../src/distance';
+
+let point1: Point = { x: 1, y: 1 };
+
+let point2: Point = { x: 4, y: 5 };
+
+if(distance(point1, point2) !== 5) {
+  throw new Error('test failed');
+}
+
+if(distance(point2, point1) !== 5) {
+  throw new Error('test failed');
+}
+
+console.log('Tests succeeded');

--- a/test/fixtures/typescript-all/test/test-framework.js
+++ b/test/fixtures/typescript-all/test/test-framework.js
@@ -1,0 +1,4 @@
+require('ts-node/register');
+
+require('./distance-tests');
+

--- a/test/fixtures/typescript-all/tsconfig.json
+++ b/test/fixtures/typescript-all/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "lib": [
+      "es5",
+      "dom",
+      "scripthost",
+      "es2015.promise",
+      "es2015.collection",
+      "es2015.symbol",
+      "es2015.iterable"
+    ],
+    "module": "commonjs",
+    "target": "es5",
+    "outDir": "build/js",
+    "sourceMap": true,
+    "noEmitOnError": true,
+    "preserveConstEnums": true,
+    "strictNullChecks": false,
+    "noImplicitAny": true,
+    "noImplicitReturns": false,
+    "noImplicitThis": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "importHelpers": true,
+    "alwaysStrict": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts"
+  ],
+  "exclude": [
+    ".*/**/*",
+    "build",
+    "dist",
+    "node_modules"
+  ],
+  "compileOnSave": false
+}


### PR DESCRIPTION
This is a test fixture that you can use to see the problem.

When inside `test/fixtures/typescript-all`, after running `npm install` the following command reports missing coverage: `npm run coverage`