### PR TITLE
Remove excluded files from coverage before writing

### DIFF
--- a/index.js
+++ b/index.js
@@ -367,6 +367,13 @@ NYC.prototype.writeCoverageFile = function () {
   var coverage = coverageFinder()
   if (!coverage) return
 
+  // Remove any files that should be excluded but snuck into the coverage
+  Object.keys(coverage).forEach(function (absFile) {
+    if (!this.exclude.shouldInstrument(absFile)) {
+      delete coverage[absFile]
+    }
+  }, this)
+
   if (this.cache) {
     Object.keys(coverage).forEach(function (absFile) {
       if (this.hashCache[absFile] && coverage[absFile]) {


### PR DESCRIPTION
Fixes #581 by scrubbing the coverage object to remove any excluded files for which coverage was generated.

I'll admit to not being entirely sure how the coverage gets in for those files in the first place (the exclude logic appears to be running correctly in `addAllFiles()`), but this provides a catch-all at the end of processing to clean it up.

There's also a question about whether the scrub should occur before or after following source maps. Doing it before seems to make the most sense based on how things work now.