### PR TITLE
Create sourcemap in instrumented files

### DIFF
--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -27,6 +27,11 @@ exports.builder = function (yargs) {
       type: 'boolean',
       description: 'should nyc detect and handle source maps?'
     })
+    .option('produce-source-map', {
+      default: false,
+      type: 'boolean',
+      description: "should nyc's instrumenter produce source maps?"
+    })
     .option('instrument', {
       default: true,
       type: 'boolean',
@@ -44,6 +49,7 @@ exports.handler = function (argv) {
   var nyc = new NYC({
     instrumenter: argv.instrumenter,
     sourceMap: argv.sourceMap,
+    produceSourceMap: argv.produceSourceMap,
     extension: argv.extension,
     require: argv.require
   })


### PR DESCRIPTION
If invoked with `nyc instrument` it wasn's possible to attach the sourcemap. This created problems for me in the coverage reports created.