### PR TITLE
Only apps should have lockfiles

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
This prevents package-lock.json from being created locally. It's already gitignored, but local devs won't have an accurate experience when the lockfile exists.

This fixes that.