### PR TITLE
Update spawn-wrap to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "resolve-from": "^2.0.0",
     "rimraf": "^2.5.4",
     "signal-exit": "^3.0.1",
-    "spawn-wrap": "^1.3.8",
+    "spawn-wrap": "^1.4.0",
     "test-exclude": "^4.1.1",
     "yargs": "^8.0.1",
     "yargs-parser": "^5.0.0"


### PR DESCRIPTION
This patch upgrades nyc to spawn-wrap v1.4.0 to allow for setting a custom base path for the spawn-wrap temporary directory. This allows for more customization in the location of files created on disk, to allow for running coverage in environments where write access to the file system is limited.

I'm not actually sure why this change is required. In the nyc `package.json` file, the version is set to `^1.3.8`, which I thought would allow 1.4.0 to install. However, when i set `"nyc": "^11.2.1"` in my devDependencies, and do `npm i && npm ls spawn-wrap` from a clean slate with no `package-lock.json`, I get

```
└─┬ nyc@11.2.1
  └── spawn-wrap@1.3.8
```

I'm running node v8.7.0 and npm v5.4.2