### PR TITLE
Correct examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,14 +154,14 @@ nyc can fail tests if coverage falls below a threshold.
 After running your tests with nyc, simply run:
 
 ```shell
-nyc --check-coverage --lines 95 --functions 95 --branches 95
+nyc check-coverage --lines 95 --functions 95 --branches 95
 ```
 
 nyc also accepts a `--check-coverage` shorthand, which can be used to
 both run tests and check that coverage falls within the threshold provided:
 
 ```shell
-nyc --check-coverage --lines 100 npm test
+nyc check-coverage --lines 100 npm test
 ```
 
 The above check fails if coverage falls below 100%.
@@ -169,7 +169,7 @@ The above check fails if coverage falls below 100%.
 To check thresholds on a per-file basis run:
 
 ```shell
-nyc --check-coverage --lines 95 --per-file
+nyc check-coverage --lines 95 --per-file
 ```
 
 ## Running reports


### PR DESCRIPTION
In the sample code, `check-coverage` was being shown as a flag (with dashes) rather than a straight up command.