### PR TITLE
Instrumenter test and callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,6 +231,7 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
   } catch (err) {
     return cb(err)
   }
+  cb()
 }
 
 NYC.prototype.walkAllFiles = function (dir, visitor) {

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -54,7 +54,11 @@ exports.handler = function (argv) {
   })
 
   nyc.instrumentAllFiles(argv.input, argv.output, function (err) {
-    if (err) console.error(err.message)
-    process.exit(1)
+    if (err) {
+      console.error(err.message)
+      process.exit(1)
+    } else {
+      process.exit(0)
+    }
   })
 }

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -479,6 +479,23 @@ describe('the nyc cli', function () {
           done()
         })
       })
+
+      it('allows a sub-directory of files to be instrumented', function (done) {
+        var args = [bin, 'instrument', './subdir/input-dir', './output']
+
+        var proc = spawn(process.execPath, args, {
+          cwd: fixturesCLI,
+          env: env
+        })
+
+        proc.on('close', function (code) {
+          code.should.equal(0)
+          var files = fs.readdirSync(path.resolve(fixturesCLI, './output'))
+          files.should.include('index.js')
+          rimraf.sync(path.resolve(fixturesCLI, 'output'))
+          done()
+        })
+      })
     })
   })
 


### PR DESCRIPTION
@bcoe As #697 fixed the source-map issues I was looking to fix in #696, this PR only contains the other minor fixes included in that PR.

Specifically:

- Added a test to prove sub-directories can be instrumented
- Added a missing callback call and exit code to ensure all tests still pass
