### PR TITLE
chore: build and test against new node8 (LTS)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: node_js
 node_js:
+  - 8
   - 6
   - 4
   - "stable"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 environment:
   matrix:
-    - nodejs_version: '6' # stable
-    - nodejs_version: '4' # LTS
+    - nodejs_version: '9' # stable
+    - nodejs_version: '8' # LTS
+    - nodejs_version: '6' # LTS
+    - nodejs_version: '4'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm cache clear

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,8 @@
 environment:
   matrix:
-    - nodejs_version: '9' # stable
     - nodejs_version: '8' # LTS
     - nodejs_version: '6' # LTS
-    - nodejs_version: '4'
+    - nodejs_version: '4' # Maintenance LTS
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm cache clear


### PR DESCRIPTION
Now that [Node 8 is LTS](https://github.com/nodejs/Release), I've added the it to appveyor and travis build configurations.

This makes sure that all LTS versions of node are explicitly being tested against:

- 4 (Maintenance LTS)
- 6 (Active LTS)
- 8 (Active LTS)