### PR TITLE
Add a new argument to specify a different path for nycrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ node_modules
 test/build/
 .self_coverage
 *.covered.js
+*.swp
 needs-transpile.js
 package-lock.json

--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -19,7 +19,8 @@ var wrapper = require.resolve('./wrap.js')
 // reporting, instrumenting subprocesses, etc.
 var yargs = configUtil.addCommandsAndHelp(configUtil.buildYargs())
 var instrumenterArgs = processArgs.hideInstrumenteeArgs()
-var argv = yargs.parse(instrumenterArgs)
+var config = configUtil.loadConfig(processArgs.parseArgs())
+var argv = yargs.config(config).parse(instrumenterArgs)
 
 if (argv._[0] === 'report') {
   // look in lib/commands/report.js for logic.

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -18,8 +18,8 @@ function guessCWD (cwd) {
   return cwd
 }
 
-function loadConfig (argv, cwd) {
-  const rcPath = findUp.sync([argv.nycrcPath || '.nycrc', '.nycrc.json'], {cwd: cwd})
+Config.loadConfig = function (argv, cwd) {
+  const rcPath = findUp.sync([argv.nycrcPath || '.nycrc', '.nycrc.json'], {cwd: guessCWD(cwd)})
   let config = {}
 
   if (rcPath) {
@@ -40,11 +40,6 @@ function loadConfig (argv, cwd) {
 // that would cause the application to exit early.
 Config.buildYargs = function (cwd) {
   cwd = guessCWD(cwd)
-  const argv = Yargs(process.argv)
-    .help(false)
-    .version(false)
-    .parse()
-  const config = loadConfig(argv, cwd)
   return Yargs([])
     .usage('$0 [command] [options]')
     .usage('$0 [options] [bin-to-instrument]')
@@ -217,7 +212,6 @@ Config.buildYargs = function (cwd) {
     .epilog('visit https://git.io/vHysA for list of available reporters')
     .boolean('h')
     .boolean('version')
-    .config(config)
     .help(false)
     .version(false)
 }

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -19,7 +19,7 @@ function guessCWD (cwd) {
 }
 
 function loadConfig (argv, cwd) {
-  const rcPath = findUp.sync(['.nycrc', '.nycrc.json'], {cwd: cwd})
+  const rcPath = findUp.sync([argv.nycrcPath || '.nycrc', '.nycrc.json'], {cwd: cwd})
   let config = {}
 
   if (rcPath) {
@@ -40,7 +40,11 @@ function loadConfig (argv, cwd) {
 // that would cause the application to exit early.
 Config.buildYargs = function (cwd) {
   cwd = guessCWD(cwd)
-  const config = loadConfig()
+  const argv = Yargs(process.argv)
+    .help(false)
+    .version(false)
+    .parse()
+  const config = loadConfig(argv, cwd)
   return Yargs([])
     .usage('$0 [command] [options]')
     .usage('$0 [options] [bin-to-instrument]')
@@ -194,6 +198,11 @@ Config.buildYargs = function (cwd) {
       describe: 'should the .nyc_output folder be cleaned before executing tests',
       default: true,
       type: 'boolean',
+      global: false
+    })
+    .option('nycrc-path', {
+      default: '.nycrc',
+      description: 'specify a different .nycrc path',
       global: false
     })
     .option('temp-directory', {

--- a/lib/process-args.js
+++ b/lib/process-args.js
@@ -16,6 +16,11 @@ module.exports = {
     }
     return argv
   },
+  parseArgs: function () {
+    var argv = process.argv.slice(2)
+    var yargv = parser(argv)
+    return yargv
+  },
   // don't pass arguments for the bin being
   // instrumented to nyc.
   hideInstrumenteeArgs: function () {

--- a/test/fixtures/cli/nycrc/.nycrc-config.json
+++ b/test/fixtures/cli/nycrc/.nycrc-config.json
@@ -1,0 +1,9 @@
+{
+  "check-coverage": true,
+  "per-file": true,
+  "lines": 100,
+  "statements": 100,
+  "functions": 100,
+  "branches": 100,
+  "exclude": []
+}

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -333,6 +333,28 @@ describe('the nyc cli', function () {
         })
       })
 
+      it('loads configuration from different file rather than .nycrc', function (done) {
+        var args = [bin, '--nycrc-path', './.nycrc-config.json', process.execPath, './index.js']
+
+        var proc = spawn(process.execPath, args, {
+          cwd: cwd,
+          env: env
+        })
+
+        var stdout = ''
+        proc.stdout.on('data', function (chunk) {
+          stdout += chunk
+        })
+
+        proc.on('close', function (code) {
+          // should be 1 due to coverage check
+          code.should.equal(1)
+          stdout.should.match(/SF:.*index\.js/)
+          stdout.should.match(/SF:.*ignore\.js/)
+          done()
+        })
+      })
+
       it('allows .nycrc configuration to be overridden with command line args', function (done) {
         var args = [bin, '--exclude=foo.js', process.execPath, './index.js']
 

--- a/test/process-args.js
+++ b/test/process-args.js
@@ -76,4 +76,25 @@ describe('process-args', function () {
       munged.should.eql(['--version'])
     })
   })
+
+  describe('parseArgs', function () {
+    it('parses arguments such as --nycrc-path --reporter --arg', function () {
+      process.argv = ['/Users/benjamincoe/bin/iojs',
+        '/Users/benjamincoe/bin/nyc.js',
+        '--nycrc-path',
+        './.nycrc-config.json',
+        '--reporter',
+        'lcov',
+        'node',
+        'test/nyc-tap.js',
+        '--arg',
+        '--'
+      ]
+
+      var munged = processArgs.parseArgs()
+      munged.nycrcPath.should.eql('./.nycrc-config.json')
+      munged.reporter.should.eql('lcov')
+      munged.arg.should.eql(true)
+    })
+  })
 })


### PR DESCRIPTION
This PR allows us to specify a different path for `.nycrc`.

> NOTE: Some projects need different settings for _backend_ and _frontend_ tests. I'm working on a project that we do need different settings for both _backend_ and _frontend_ tests.

> Also [mocha](https://mochajs.org/) allows us to do it as well, by providing the argument `--opts`.

Thanks for understanding.