### PR TITLE
add command line options to control compacting and comment removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,9 @@ NYC.prototype.instrumenter = function () {
 
 NYC.prototype._createInstrumenter = function () {
   return this._instrumenterLib(this.cwd, {
-    produceSourceMap: this.config.produceSourceMap
+    produceSourceMap: this.config.produceSourceMap,
+    compact: this.config.compact,
+    preserveComments: this.config.preserveComments
   })
 }
 

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -31,6 +31,16 @@ exports.builder = function (yargs) {
       type: 'boolean',
       description: "should nyc's instrumenter produce source maps?"
     })
+    .option('compact', {
+      default: true,
+      type: 'boolean',
+      description: 'should the output be compacted?'
+    })
+    .option('preserve-comments', {
+      default: true,
+      type: 'boolean',
+      description: 'should comments be preserved in the output?'
+    })
     .option('instrument', {
       default: true,
       type: 'boolean',
@@ -50,7 +60,9 @@ exports.handler = function (argv) {
     sourceMap: argv.sourceMap,
     produceSourceMap: argv.produceSourceMap,
     extension: argv.extension,
-    require: argv.require
+    require: argv.require,
+    compact: argv.compact,
+    preserveComments: argv.preserveComments
   })
 
   nyc.instrumentAllFiles(argv.input, argv.output, function (err) {

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -165,6 +165,16 @@ Config.buildYargs = function (cwd) {
       description: "should nyc's instrumenter produce source maps?",
       global: false
     })
+    .option('compact', {
+      default: true,
+      type: 'boolean',
+      description: 'should the output be compacted?'
+    })
+    .option('preserve-comments', {
+      default: true,
+      type: 'boolean',
+      description: 'should comments be preserved in the output?'
+    })
     .option('instrument', {
       default: true,
       type: 'boolean',

--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -9,8 +9,8 @@ function InstrumenterIstanbul (cwd, options) {
     autoWrap: true,
     coverageVariable: '__coverage__',
     embedSource: true,
-    noCompact: false,
-    preserveComments: true,
+    compact: options.compact,
+    preserveComments: options.preserveComments,
     produceSourceMap: options.produceSourceMap,
     esModules: true
   })


### PR DESCRIPTION
- there is no noCompact option in istanbul, only a compact option. fixed its usage
- add --[no-]compact and --[no-]preserve-comments and pass them on to
  istanbul

I wasn't 100% sure what the default for preserveComments should be. Reading the code, it seemed to me that the intention was to have comments stripped by default but the current behaviour is to not strip comments, so I stuck with the current behaviour in order to keep the users' setups the same.

Please note that due to a bug in istanbul-lib-instrument, the preserveComments option set to false doesn't do anything yet. I filed another pull request with a fix for that as well: https://github.com/istanbuljs/istanbuljs/pull/122

I hope the changes are OK, please let me know if not :-)