### PR TITLE
Fix typo

### DIFF
--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -47,7 +47,7 @@ Config.buildYargs = function (cwd) {
       alias: 'r',
       describe: 'coverage reporter(s) to use',
       default: 'text',
-      globa: false
+      global: false
     })
     .option('report-dir', {
       describe: 'directory to output coverage reports in',


### PR DESCRIPTION
https://github.com/yargs/yargs/blob/master/docs/api.md#global

> Options default to being global.

This patch changes `reporter` from global to not global.
It may break something. However, the broken behavior is not intended.