### PR TITLE
chore: remove greenkeeper ignore for find-up

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,10 +156,5 @@
     "test-exclude",
     "yargs",
     "yargs-parser"
-  ],
-  "greenkeeper": {
-    "ignore": [
-      "find-up"
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
Originally this was added in #402 but find-up has since been updated