### PR TITLE
docs: reference minimatch usage and explain pattern expansions

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ an `include` key with a list of globs to specify specific files that should be c
 }
 ```
 
+> `nyc` uses micromatch for glob expansions, you can read its documentation [here](https://www.npmjs.com/package/micromatch).
+
 > Note: include defaults to `['**']`
 
 > ### Use the `--all` flag to include files that have not been required in your tests.


### PR DESCRIPTION
I've added a reference to the NPM package `minimatch` that is used internally by the NPM package `test-exclude`, to provide developers with a guide to the allowed matching features.

I've also described how internally more patterns are added depending on the provided patterns.

That said, I think [this regexp](https://github.com/istanbuljs/istanbuljs/blob/master/packages/test-exclude/index.js#L114) is wrong, since it only adds `file.js` when `**/file.js` provided. If I provide `./lib/**/*.js`, it doesn't add `./lib/*.js` automatically.

This regexp could be changed to `/\*\*/g`, assuming the developer only uses the double asterisks once inside the pattern, so it only expands (adds the new pattern) if the pattern (or the last path token) is a name without special matching characters. Any other case should be directly managed by the developer with the proper minimatch pattern.

This way:

- `**/file.js` adds `file.js`
- `./lib/**/*.js` adds `./lib/*.js`

I think [the other regexp](https://github.com/istanbuljs/istanbuljs/blob/master/packages/test-exclude/index.js#L109) could also be improved, since it adds the pattern `./lib/**` when `./lib` provided, but if I provide `./lib/**/*.js` it also adds `./lib/**/*.js/**`, which is wrong. It could be changed to `/(\/[^*\/]*$|^[^*\/]+$)/`, so it appends the double asterisks when there are no asterisks at all in the pattern.

This way:

- `lib/*.js` does nothing.
- `lib/**` does nothing.
- `lib` adds `lib/**`.
- `./lib/folder` adds `./lib/folder/**`

Let me know if you think I'm right to make a PR to the package `test-exclude` to change those regexps!