### PR TITLE
bump yargs version for extending configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "signal-exit": "^3.0.1",
     "spawn-wrap": "^1.4.2",
     "test-exclude": "^4.2.0",
-    "yargs": "^10.0.3",
+    "yargs": "11.1.0",
     "yargs-parser": "^8.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Pulled in the new version of yargs that allows extending `rc` files so consumers of this module can extend `.nycrc`. 