### PR TITLE
Added "temp-directory" to configuring nyc

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Any configuration options that can be set via the command line can also be speci
     ],
     "cache": true,
     "all": true,
+    "temp-directory": "./alternative-tmp",
     "report-dir": "./alternative"
   }
 }


### PR DESCRIPTION
I had to search through the issues to find the proper naming convention for setting the `temp-directory`. This little PR adds it where I would have expected to find it.

(I hope this is the right branch to PR against. :)