### PR TITLE
feat: allow rows with 100% statement, branch, and function coverage to be skipped in text report

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,7 +453,8 @@ NYC.prototype.report = function () {
 
   this.reporter.forEach((_reporter) => {
     tree.visit(reports.create(_reporter, {
-      skipEmpty: this.config.skipEmpty
+      skipEmpty: this.config.skipEmpty,
+      skipFull: this.config.skipFull
     }), context)
   })
 

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -227,6 +227,12 @@ Config.buildYargs = function (cwd) {
       type: 'boolean',
       global: false
     })
+    .option('skip-full', {
+      describe: 'don\'t show files with 100% statement, branch, and function coverage',
+      default: false,
+      type: 'boolean',
+      global: false
+    })
     .pkgConf('nyc', cwd)
     .example('$0 npm test', 'instrument your tests with coverage')
     .example('$0 --require babel-core/register npm test', 'instrument your tests with coverage and transpile with Babel')

--- a/test/fixtures/cli/skip-full.js
+++ b/test/fixtures/cli/skip-full.js
@@ -1,0 +1,2 @@
+require('./empty')
+require('./half-covered')

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -1003,11 +1003,11 @@ describe('the nyc cli', function () {
       const args = [
         bin,
         '--skip-full',
-        process.execPath, './instrumented/s2.min.js'
+        process.execPath, './skip-full.js'
       ]
 
       const proc = spawn(process.execPath, args, {
-        cwd: fixturesSourceMaps,
+        cwd: fixturesCLI,
         env: env
       })
 
@@ -1019,10 +1019,12 @@ describe('the nyc cli', function () {
       proc.on('close', function (code) {
         code.should.equal(0)
         stdoutShouldEqual(stdout, `
-        ----------|----------|----------|----------|----------|-------------------|
-        File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
-        ----------|----------|----------|----------|----------|-------------------|
-        ----------|----------|----------|----------|----------|-------------------|`)
+        -----------------|----------|----------|----------|----------|-------------------|
+        File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+        -----------------|----------|----------|----------|----------|-------------------|
+        All files        |     62.5 |       50 |      100 |     62.5 |                   |
+         half-covered.js |       50 |       50 |      100 |       50 |             6,7,8 |
+        -----------------|----------|----------|----------|----------|-------------------|`)
         done()
       })
     })

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -998,6 +998,36 @@ describe('the nyc cli', function () {
     })
   })
 
+  describe('skip-full', () => {
+    it('does not display files with 100% statement, branch, and function coverage', (done) => {
+      const args = [
+        bin,
+        '--skip-full',
+        process.execPath, './instrumented/s2.min.js'
+      ]
+
+      const proc = spawn(process.execPath, args, {
+        cwd: fixturesSourceMaps,
+        env: env
+      })
+
+      var stdout = ''
+      proc.stdout.on('data', function (chunk) {
+        stdout += chunk
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(0)
+        stdoutShouldEqual(stdout, `
+        ----------|----------|----------|----------|----------|-------------------|
+        File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+        ----------|----------|----------|----------|----------|-------------------|
+        ----------|----------|----------|----------|----------|-------------------|`)
+        done()
+      })
+    })
+  })
+
   describe('merge', () => {
     it('combines multiple coverage reports', (done) => {
       const args = [


### PR DESCRIPTION
@chrismohr ☝️ I note that for `skipEmpty` we actually support both text and HTML reports; might be a good next contribution for you?

CC: @coreyfarrell for review.