### PR TITLE
chore: Update caching-transform.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -806,23 +806,14 @@
       }
     },
     "caching-transform": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
-      "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-2.0.0.tgz",
+      "integrity": "sha512-tTfemGmFWe7KZ3KN6VsSgQZbd9Bgo7A40wlp4PTsJJvFu4YAnEC5YnfdiKq6Vh2i9XJLnA9n8OXD46orVpnPMw==",
       "requires": {
-        "md5-hex": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "write-file-atomic": "^1.1.4"
-      },
-      "dependencies": {
-        "md5-hex": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
-          "requires": {
-            "md5-o-matic": "^0.1.1"
-          }
-        }
+        "make-dir": "^1.0.0",
+        "md5-hex": "^2.0.0",
+        "package-hash": "^2.0.0",
+        "write-file-atomic": "^2.0.0"
       }
     },
     "caller-path": {
@@ -1590,6 +1581,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.1"
       }
+    },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -2991,6 +2987,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
       "dev": true
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -6141,6 +6142,17 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
+    "package-hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-2.0.0.tgz",
+      "integrity": "sha1-eK4ybIngWk2BO2hgGXevBcANKg0=",
+      "requires": {
+        "graceful-fs": "^4.1.11",
+        "lodash.flattendeep": "^4.4.0",
+        "md5-hex": "^2.0.0",
+        "release-zalgo": "^1.0.0"
+      }
+    },
     "parse-github-repo-url": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
@@ -6470,6 +6482,14 @@
         "strip-indent": "^2.0.0"
       }
     },
+    "release-zalgo": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "requires": {
+        "es6-error": "^4.0.1"
+      }
+    },
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
@@ -6701,11 +6721,6 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0"
       }
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "source-map": {
       "version": "0.5.7",
@@ -7669,13 +7684,13 @@
       }
     },
     "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
+      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
+        "signal-exit": "^3.0.2"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "archy": "^1.0.0",
     "arrify": "^1.0.1",
-    "caching-transform": "^1.0.1",
+    "caching-transform": "^2.0.0",
     "convert-source-map": "^1.5.1",
     "debug-log": "^1.0.1",
     "find-cache-dir": "^1.0.0",


### PR DESCRIPTION
FYI caching-transform is no longer used by `ava@next` so they are looking to transfer to a new maintainer.  nyc will be the only major [dependent](https://www.npmjs.com/browse/depended/caching-transform).
https://github.com/avajs/caching-transform/issues/5#event-1670888693