### PR TITLE
fix: Add flag to allow instrumentation of non-strict scripts.

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,8 @@ NYC.prototype._createInstrumenter = function () {
     ignoreClassMethods: [].concat(this.config.ignoreClassMethod).filter(a => a),
     produceSourceMap: this.config.produceSourceMap,
     compact: this.config.compact,
-    preserveComments: this.config.preserveComments
+    preserveComments: this.config.preserveComments,
+    esModules: this.config.esModules
   })
 }
 
@@ -282,8 +283,9 @@ NYC.prototype._transformFactory = function (cacheDir) {
     try {
       instrumented = instrumenter.instrumentSync(code, filename, sourceMap)
     } catch (e) {
-      debugLog('failed to instrument ' + filename + 'with error: ' + e.stack)
+      debugLog('failed to instrument ' + filename + ' with error: ' + e.stack)
       if (this.config.exitOnError) {
+        console.error('Failed to instrument ' + filename)
         process.exit(1)
       } else {
         instrumented = code

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -115,6 +115,12 @@ Config.buildYargs = function (cwd) {
       describe: 'cache babel transpilation results for improved performance',
       global: false
     })
+    .option('es-modules', {
+      default: false,
+      type: 'boolean',
+      describe: 'tell the instrumenter to treat files as ES Modules',
+      global: false
+    })
     .option('extension', {
       alias: 'e',
       default: [],

--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -13,7 +13,7 @@ function InstrumenterIstanbul (cwd, options) {
     preserveComments: options.preserveComments,
     produceSourceMap: options.produceSourceMap,
     ignoreClassMethods: options.ignoreClassMethods,
-    esModules: true
+    esModules: options.esModules
   })
 
   return {

--- a/test/fixtures/cli/not-strict.js
+++ b/test/fixtures/cli/not-strict.js
@@ -1,0 +1,5 @@
+function package() {
+	return 1;
+}
+
+package();

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -1030,6 +1030,76 @@ describe('the nyc cli', function () {
     })
   })
 
+  describe('es-modules', () => {
+    it('allows reserved word when es-modules is disabled', (done) => {
+      const args = [
+        bin,
+        '--cache', 'false',
+        process.execPath, './not-strict.js'
+      ]
+
+      const proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      var stdout = ''
+      proc.stdout.on('data', function (chunk) {
+        stdout += chunk
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(0)
+        stdoutShouldEqual(stdout, `
+        ---------------|----------|----------|----------|----------|-------------------|
+        File           |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+        ---------------|----------|----------|----------|----------|-------------------|
+        All files      |      100 |      100 |      100 |      100 |                   |
+         not-strict.js |      100 |      100 |      100 |      100 |                   |
+        ---------------|----------|----------|----------|----------|-------------------|`)
+        done()
+      })
+    })
+
+    it('forbids reserved word when es-modules is not disabled', (done) => {
+      const args = [
+        bin,
+        '--cache', 'false',
+        '--es-modules', 'true',
+        '--exit-on-error', 'true',
+        process.execPath, './not-strict.js'
+      ]
+
+      const proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      var stdout = ''
+      proc.stdout.on('data', function (chunk) {
+        stdout += chunk
+      })
+
+      var stderr = ''
+      proc.stderr.on('data', function (chunk) {
+        stderr += chunk
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(1)
+        stdoutShouldEqual(stderr, `
+        Failed to instrument ${path.join(fixturesCLI, 'not-strict.js')}`)
+        stdoutShouldEqual(stdout, `
+        ----------|----------|----------|----------|----------|-------------------|
+        File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+        ----------|----------|----------|----------|----------|-------------------|
+        All files |        0 |        0 |        0 |        0 |                   |
+        ----------|----------|----------|----------|----------|-------------------|`)
+        done()
+      })
+    })
+  })
+
   describe('merge', () => {
     it('combines multiple coverage reports', (done) => {
       const args = [


### PR DESCRIPTION
nyc was hard-coded to use `esModules: true` when running the
instrumenter.  This could result in certain scripts not being
instrumented.

```js
function package() {
  return 'package is a reserved keyword'
}

console.log(package())
```

Using `--es-modules false` will allow this script to be instrumented.

Issue #796