### PR TITLE
fix: Update caching-transform options.

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,13 +91,11 @@ function NYC (config) {
 }
 
 NYC.prototype._createTransform = function (ext) {
-  var _this = this
   var opts = {
     salt: Hash.salt,
-    hash: function (code, metadata, salt) {
-      var hash = Hash(code, metadata.filename)
-      _this.hashCache[metadata.filename] = hash
-      return hash
+    hashData: (input, metadata) => [metadata.filename],
+    onHash: (input, metadata, hash) => {
+      this.hashCache[metadata.filename] = hash
     },
     cacheDir: this.cacheDirectory,
     // when running --all we should not load source-file from

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,14 +1,8 @@
-const CACHE_VERSION = require('../package.json').version
-const md5hex = require('md5-hex')
-const salt = JSON.stringify({
-  istanbul: require('istanbul-lib-coverage/package.json').version,
-  nyc: CACHE_VERSION
-})
+'use strict'
 
-function Hash (code, filename) {
-  return md5hex([code, filename, salt]) + '_' + CACHE_VERSION
+module.exports = {
+  salt: JSON.stringify({
+    istanbul: require('istanbul-lib-coverage/package.json').version,
+    nyc: require('../package.json').version
+  })
 }
-
-Hash.salt = salt
-
-module.exports = Hash

--- a/test/fixtures/identical-file-runner.js
+++ b/test/fixtures/identical-file-runner.js
@@ -1,0 +1,14 @@
+const path = require('path')
+const assert = require('assert')
+const file1 = require('./identical-file1.js')
+const file2 = require('./identical-file2.js')
+
+assert.equal(file1(), file2())
+
+const cov = (new Function('return this.__coverage__'))()
+
+assert.deepEqual(Object.keys(cov).sort(), [
+  __filename,
+  path.resolve('identical-file1.js'),
+  path.resolve('identical-file2.js')
+])

--- a/test/fixtures/identical-file1.js
+++ b/test/fixtures/identical-file1.js
@@ -1,0 +1,5 @@
+function identical() {
+	return 'identical'
+}
+
+module.exports = identical

--- a/test/fixtures/identical-file2.js
+++ b/test/fixtures/identical-file2.js
@@ -1,0 +1,5 @@
+function identical() {
+	return 'identical'
+}
+
+module.exports = identical

--- a/test/src/nyc-tap.js
+++ b/test/src/nyc-tap.js
@@ -457,5 +457,22 @@ describe('nyc', function () {
         done()
       })
     })
+
+    it('handles identical files', function (done) {
+      var nyc = new NYC(configUtil.buildYargs(fixtures).parse())
+      nyc.clearCache()
+
+      var args = [bin, process.execPath, './identical-file-runner.js']
+
+      var proc = spawn(process.execPath, args, {
+        cwd: fixtures,
+        env: {}
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(0)
+        done()
+      })
+    })
   })
 })


### PR DESCRIPTION
When updating caching--transform it was missed that the `hash` option
has been refactored.  This means that two files with identical contents
would be treated as identical.

Add a test to verify that two sources with identical contents are
both instrumented.