### PR TITLE
fix: Enable es-modules by default.

### DIFF
--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -116,7 +116,7 @@ Config.buildYargs = function (cwd) {
       global: false
     })
     .option('es-modules', {
-      default: false,
+      default: true,
       type: 'boolean',
       describe: 'tell the instrumenter to treat files as ES Modules',
       global: false

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -1035,6 +1035,7 @@ describe('the nyc cli', function () {
       const args = [
         bin,
         '--cache', 'false',
+        '--es-modules', 'false',
         process.execPath, './not-strict.js'
       ]
 
@@ -1065,7 +1066,6 @@ describe('the nyc cli', function () {
       const args = [
         bin,
         '--cache', 'false',
-        '--es-modules', 'true',
         '--exit-on-error', 'true',
         process.execPath, './not-strict.js'
       ]


### PR DESCRIPTION
A previous fix for #796 added an es-modules option and set it false by
default.  This default was a change of behavior in NYC as previously all
sources were parsed as ES modules by the instrumenter.  I believe the
old behavior is the correct default because it allows NYC to work with
modern code.  Code which uses certain features which violate strict mode
will have to disable es-modules.  This will not effect ES5 which follows
the rules of 'use strict'.