### PR TITLE
Rename --temp-directory option to --temp-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Any configuration options that can be set via the command line can also be speci
     ],
     "cache": true,
     "all": true,
-    "temp-directory": "./alternative-tmp",
+    "temp-dir": "./alternative-tmp",
     "report-dir": "./alternative"
   }
 }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function NYC (config) {
   this.config = config
 
   this.subprocessBin = config.subprocessBin || path.resolve(__dirname, './bin/nyc.js')
-  this._tempDirectory = config.tempDir || './.nyc_output'
+  this._tempDirectory = config.tempDir || config.tempDirectory || './.nyc_output'
   this._instrumenterLib = require(config.instrumenter || './lib/instrumenters/istanbul')
   this._reportDir = config.reportDir || 'coverage'
   this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function NYC (config) {
   this.config = config
 
   this.subprocessBin = config.subprocessBin || path.resolve(__dirname, './bin/nyc.js')
-  this._tempDirectory = config.tempDirectory || './.nyc_output'
+  this._tempDirectory = config.tempDir || './.nyc_output'
   this._instrumenterLib = require(config.instrumenter || './lib/instrumenters/istanbul')
   this._reportDir = config.reportDir || 'coverage'
   this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true

--- a/lib/commands/merge.js
+++ b/lib/commands/merge.js
@@ -24,7 +24,8 @@ exports.builder = function (yargs) {
       type: 'text',
       default: 'coverage.json'
     })
-    .option('temp-directory', {
+    .option('temp-dir', {
+      alias: 'temp-directory',
       describe: 'directory to read raw coverage information from',
       default: './.nyc_output'
     })

--- a/lib/commands/merge.js
+++ b/lib/commands/merge.js
@@ -25,9 +25,12 @@ exports.builder = function (yargs) {
       default: 'coverage.json'
     })
     .option('temp-dir', {
-      alias: 'temp-directory',
+      alias: 't',
       describe: 'directory to read raw coverage information from',
       default: './.nyc_output'
+    })
+    .option('temp-directory', {
+      hidden: true
     })
     .example('$0 merge ./out coverage.json', 'merge together reports in ./out and output as coverage.json')
 }

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -21,9 +21,12 @@ exports.builder = function (yargs) {
       default: 'coverage'
     })
     .option('temp-dir', {
-      alias: 'temp-directory',
+      alias: 't',
       describe: 'directory to read raw coverage information from',
       default: './.nyc_output'
+    })
+    .option('temp-directory', {
+      hidden: true
     })
     .option('show-process-tree', {
       describe: 'display the tree of spawned processes',

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -20,7 +20,8 @@ exports.builder = function (yargs) {
       describe: 'directory to output coverage reports in',
       default: 'coverage'
     })
-    .option('temp-directory', {
+    .option('temp-dir', {
+      alias: 'temp-directory',
       describe: 'directory to read raw coverage information from',
       default: './.nyc_output'
     })

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -223,9 +223,12 @@ Config.buildYargs = function (cwd) {
       global: false
     })
     .option('temp-dir', {
-      alias: 'temp-directory',
       describe: 'directory to output raw coverage information to',
       default: './.nyc_output',
+      global: false
+    })
+    .option('temp-directory', {
+      hidden: true,
       global: false
     })
     .option('skip-empty', {

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -223,6 +223,7 @@ Config.buildYargs = function (cwd) {
       global: false
     })
     .option('temp-dir', {
+      alias: 't',
       describe: 'directory to output raw coverage information to',
       default: './.nyc_output',
       global: false

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -222,7 +222,8 @@ Config.buildYargs = function (cwd) {
       description: 'specify a different .nycrc path',
       global: false
     })
-    .option('temp-directory', {
+    .option('temp-dir', {
+      alias: 'temp-directory',
       describe: 'directory to output raw coverage information to',
       default: './.nyc_output',
       global: false

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "build": "node ./build-tests",
     "instrument": "node ./build-self-coverage.js",
     "test-integration": "tap -t120 --no-cov -b ./test/build/*.js && mocha --timeout=15000 ./test/nyc-bin.js",
-    "test-mocha": "node ./bin/nyc --no-clean --silent --temp-directory=./.self_coverage mocha ./test/nyc.js ./test/process-args.js",
-    "report": "node ./bin/nyc  --temp-directory ./.self_coverage/ -r text -r lcov report",
+    "test-mocha": "node ./bin/nyc --no-clean --silent --temp-dir=./.self_coverage mocha ./test/nyc.js ./test/process-args.js",
+    "report": "node ./bin/nyc  --temp-dir ./.self_coverage/ -r text -r lcov report",
     "release": "standard-version"
   },
   "bin": {


### PR DESCRIPTION
This change makes the option naming consistent using the form --*-dir, fixes #895 

Deprecates the option name --temp-directory in favour of --temp-dir.  --temp-directory has been demoted to a yargs alias of --temp-dir, so it will still work with existing projects.  I've updated the docs and changed the package.json test scripts to use the newer form.

I'm a little unsure of how tests should work for this, I've modified the package.json tests to use the new form, but then that doesn't test that the deprecated form still works, thoughts?