### PR TITLE
feature: add alias for --temp-directory CLI flag

### DIFF
--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -223,6 +223,7 @@ Config.buildYargs = function (cwd) {
       global: false
     })
     .option('temp-directory', {
+      alias: 't',
       describe: 'directory to output raw coverage information to',
       default: './.nyc_output',
       global: false


### PR DESCRIPTION
I find myself using the `--temp-directory` flag quite often, as I don't like nyc's default behavior of writing `.nyc_output` to my root directory. This PR adds an alias for this flag allowing me to do:

```
nyc -t coverage -i esm -r lcov node test.js
```