### PR TITLE
[docs] @babel/env should be @babel/preset-env

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ We recommend using [`babel-plugin-istanbul`] if your project uses the babel tool
   ```json
     {
       "babel": {
-        "presets": ["@babel/env"],
+        "presets": ["@babel/preset-env"],
         "env": {
           "test": {
             "plugins": ["istanbul"]


### PR DESCRIPTION
It's not `@babel/env`, it's `@babel/preset-env`