### PR TITLE
feat: avoid hardcoded HOME for spawn-wrap working dir

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -42,6 +42,9 @@ if ([
   if (argv.all) nyc.addAllFiles()
 
   var env = {
+    // Support running nyc as a user without HOME (e.g. linux 'nobody'),
+    // https://github.com/istanbuljs/nyc/issues/951
+    SPAWN_WRAP_SHIM_ROOT: process.env.SPAWN_WRAP_SHIM_ROOT || process.env.XDG_CACHE_HOME || require('os').homedir(),
     NYC_CONFIG: JSON.stringify(argv),
     NYC_CWD: process.cwd(),
     NYC_ROOT_ID: nyc.rootId,


### PR DESCRIPTION
By default, spawn-wrap writes temporary files to HOME.
It used to be /tmp, but it changed that to HOME to support
environments that have 'noexec' flags set on their tmpfs mount.
Ref https://github.com/tapjs/spawn-wrap/issues/3.

The problem with this is that nyc now no longer works in environments
without a (writable) home directory (e.g. the 'nobody' user on
Linux).

While it is fine to fallback to HOME, it should write elsewhere
if that is unavailable, and ideally in a way that doesn't require
every sysadmin or end-user to hardcode some environment variable
in their package.json specifically for nyc or spawn-wrap.

A common way to communicate this intent is with the XDG_CACHE_HOME
environment variable.

Fixes #951.