### PR TITLE
DO NOT MERGE: Try node.js latest in appveyor.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 environment:
   matrix:
+    - nodejs_version: '11.6.0'
     - nodejs_version: '10' # stable
     - nodejs_version: '8' # LTS
     - nodejs_version: '6'


### PR DESCRIPTION
#961 is testing migration to travis-ci, node.js latest is throwing `ENOMEM`.  The point of this PR is to see if we get the same result in appveyor.