### PR TITLE
Make update to caching information in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,9 +251,7 @@ modules should be required in the subprocess collecting coverage:
 
 ## Caching
 
-You can run `nyc` with the optional `--cache` flag, to prevent it from
-instrumenting the same files multiple times. This can significantly
-improve runtime performance.
+`nyc`'s default behavior is to cache instrumented files to disk to prevent instrumenting source files multiple times, and speed `nyc` execution times. You can disable this behavior by running `nyc` with the `--cache false` flag. You can also change the default cache directory from `./node_modules/.cache/nyc` by setting the `--cacheDir` flag.
 
 ## Configuring `nyc`
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ modules should be required in the subprocess collecting coverage:
 
 ## Caching
 
-`nyc`'s default behavior is to cache instrumented files to disk to prevent instrumenting source files multiple times, and speed `nyc` execution times. You can disable this behavior by running `nyc` with the `--cache false` flag. You can also change the default cache directory from `./node_modules/.cache/nyc` by setting the `--cacheDir` flag.
+`nyc`'s default behavior is to cache instrumented files to disk to prevent instrumenting source files multiple times, and speed `nyc` execution times. You can disable this behavior by running `nyc` with the `--cache false` flag. You can also change the default cache directory from `./node_modules/.cache/nyc` by setting the `--cache-dir` flag.
 
 ## Configuring `nyc`
 

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -109,6 +109,10 @@ Config.buildYargs = function (cwd) {
       describe: 'cache instrumentation results for improved performance',
       global: false
     })
+    .option('cache-dir', {
+      describe: 'explicitly set location for instrumentation cache',
+      global: false
+    })
     .option('babel-cache', {
       default: false,
       type: 'boolean',

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -278,7 +278,8 @@ describe('the nyc cli', function () {
         '--include=env.js',
         '--exclude=batman.js',
         '--extension=.js',
-        '--cache=true',
+        '--cache=false',
+        '--cache-dir=/tmp',
         '--source-map=true',
         process.execPath,
         './env.js'
@@ -286,7 +287,8 @@ describe('the nyc cli', function () {
       var expected = {
         instrumenter: './lib/instrumenters/istanbul',
         silent: true,
-        cache: true,
+        cacheDir: '/tmp',
+        cache: false,
         sourceMap: true
       }
 


### PR DESCRIPTION
Since https://github.com/istanbuljs/nyc/pull/454, caching has been enabled by default but the README does not reflect this. Our team lost some time following the README, so contributing back our findings for the next team!