### PR TITLE
Modernize lib/instrumenters.

### DIFF
--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -1,14 +1,14 @@
 'use strict'
 
-var convertSourceMap = require('convert-source-map')
-var mergeSourceMap = require('merge-source-map')
+const { createInstrumenter } = require('istanbul-lib-instrument')
+const convertSourceMap = require('convert-source-map')
+const mergeSourceMap = require('merge-source-map')
 
 function InstrumenterIstanbul (cwd, options) {
   const plugins = options.plugins
   const configPlugins = plugins ? { plugins } : {}
 
-  var istanbul = InstrumenterIstanbul.istanbul()
-  var instrumenter = istanbul.createInstrumenter(Object.assign({
+  const instrumenter = createInstrumenter(Object.assign({
     autoWrap: true,
     coverageVariable: '__coverage__',
     embedSource: true,
@@ -20,7 +20,7 @@ function InstrumenterIstanbul (cwd, options) {
   }, configPlugins))
 
   return {
-    instrumentSync: function (code, filename, sourceMap) {
+    instrumentSync (code, filename, sourceMap) {
       var instrumented = instrumenter.instrumentSync(code, filename)
       // the instrumenter can optionally produce source maps,
       // this is useful for features like remapping stack-traces.
@@ -39,16 +39,10 @@ function InstrumenterIstanbul (cwd, options) {
       }
       return instrumented
     },
-    lastFileCoverage: function () {
+    lastFileCoverage () {
       return instrumenter.lastFileCoverage()
     }
   }
-}
-
-InstrumenterIstanbul.istanbul = function () {
-  InstrumenterIstanbul._istanbul || (InstrumenterIstanbul._istanbul = require('istanbul-lib-instrument'))
-
-  return InstrumenterIstanbul._istanbul || (InstrumenterIstanbul._istanbul = require('istanbul'))
 }
 
 module.exports = InstrumenterIstanbul

--- a/lib/instrumenters/noop.js
+++ b/lib/instrumenters/noop.js
@@ -1,10 +1,10 @@
-var FileCoverage = require('istanbul-lib-coverage').classes.FileCoverage
-var readInitialCoverage = require('istanbul-lib-instrument').readInitialCoverage
+const { FileCoverage } = require('istanbul-lib-coverage').classes
+const { readInitialCoverage } = require('istanbul-lib-instrument')
 
 function NOOP () {
   return {
-    instrumentSync: function (code, filename) {
-      var extracted = readInitialCoverage(code)
+    instrumentSync (code, filename) {
+      const extracted = readInitialCoverage(code)
       if (extracted) {
         this.fileCoverage = new FileCoverage(extracted.coverageData)
       } else {
@@ -12,7 +12,7 @@ function NOOP () {
       }
       return code
     },
-    lastFileCoverage: function () {
+    lastFileCoverage () {
       return this.fileCoverage
     }
   }


### PR DESCRIPTION
**Take advantage of features available in node.js 6 and above**

* Remove unreachable code for importing legacy `istanbul` module.
* Use `const` where possible
* Use object destructuring where appropriate.
* Use short-hand function declarations
