### PR TITLE
fix: add config values to hash salt

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ function NYC (config) {
 
 NYC.prototype._createTransform = function (ext) {
   var opts = {
-    salt: Hash.salt,
+    salt: Hash.salt(this.config),
     hashData: (input, metadata) => [metadata.filename],
     onHash: (input, metadata, hash) => {
       this.hashCache[metadata.filename] = hash

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -13,12 +13,12 @@ function getInvalidatingOptions (config) {
 
 module.exports = {
   salt (config) {
-    return JSON.stringify(Object.assign(
-      {
-        istanbul: require('istanbul-lib-coverage/package.json').version,
+    return JSON.stringify({
+      modules: {
+        'istanbul-lib-instrument': require('istanbul-lib-coverage/package.json').version,
         nyc: require('../package.json').version
       },
-      getInvalidatingOptions(config)
-    ))
+      nycrc: getInvalidatingOptions(config)
+    })
   }
 }

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -21,7 +21,7 @@ module.exports = {
   salt (config) {
     return JSON.stringify({
       modules: {
-        'istanbul-lib-instrument': require('istanbul-lib-coverage/package.json').version,
+        'istanbul-lib-instrument': require('istanbul-lib-instrument/package.json').version,
         nyc: require('../package.json').version
       },
       nycrc: getInvalidatingOptions(config)

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -2,8 +2,14 @@
 
 function getInvalidatingOptions (config) {
   return [
+    'compact',
+    'esModules',
+    'ignoreClassMethods',
     'instrument',
     'instrumenter',
+    'plugins',
+    'preserveComments',
+    'produceSourceMap',
     'sourceMap'
   ].reduce((acc, optName) => {
     acc[optName] = config[optName]

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,8 +1,24 @@
 'use strict'
 
+function getInvalidatingOptions (config) {
+  return [
+    'instrument',
+    'instrumenter',
+    'sourceMap'
+  ].reduce((acc, optName) => {
+    acc[optName] = config[optName]
+    return acc
+  }, {})
+}
+
 module.exports = {
-  salt: JSON.stringify({
-    istanbul: require('istanbul-lib-coverage/package.json').version,
-    nyc: require('../package.json').version
-  })
+  salt (config) {
+    return JSON.stringify(Object.assign(
+      {
+        istanbul: require('istanbul-lib-coverage/package.json').version,
+        nyc: require('../package.json').version
+      },
+      getInvalidatingOptions(config)
+    ))
+  }
 }


### PR DESCRIPTION
This PR adds the instrumenter-related config options to the salt of the cache hash. This fixes a bug where code that has been cached without instrumentation or source maps is incorrectly reused after the options are later enabled, leading to missing instrumentation. This problem is more likely to come up in projects using `babel-plugin-istanbul` which recommends setting the `sourceMap` and `instrument` options to `false`.

Closes #552 and probably also #822 #822 #974 #980

Thank you to everyone maintaining and contributing to this project :heart: 