### PR TITLE
Demonstrate work-around for singleton pattern.

### DIFF
--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -1,4 +1,5 @@
 var sw = require('spawn-wrap')
+var singleton = require('../singleton-lib');
 var NYC
 try {
   NYC = require('../index.covered.js')
@@ -20,4 +21,12 @@ config._processInfo = {
 
 ;(new NYC(config)).wrap()
 
+singleton.write('bin/wrap.js');
+if (process.env.CLEAR_IT) {
+  Object.keys(require.cache).forEach(file => {
+    delete require.cache[file];
+  });
+}
+console.log(`bin/wrap.js before sw.runMain(): ${singleton.read()}`);
 sw.runMain()
+console.log(`bin/wrap.js after sw.runMain(): ${singleton.read()}`);

--- a/singleton-bin.js
+++ b/singleton-bin.js
@@ -1,0 +1,5 @@
+const singleton = require('./singleton-lib');
+
+console.log(`start singleton-bin.js: ${singleton.read()}`);
+singleton.write('sub-bin');
+console.log(`singleton-bin.js wrote: ${singleton.read()}`);

--- a/singleton-lib.js
+++ b/singleton-lib.js
@@ -1,0 +1,12 @@
+'use strict';
+
+let singleton;
+
+module.exports = {
+	write(value) {
+		singleton = value;
+	},
+	read() {
+		return singleton;
+	}
+};


### PR DESCRIPTION
To test this checkout the `singleton-workaround` branch and run `./bin/nyc.js node ./singleton-bin.js`.  This will output the following:
```
bin/wrap.js before sw.runMain(): bin/wrap.js
start singleton-bin.js: bin/wrap.js
singleton-bin.js wrote: sub-bin
bin/wrap.js after sw.runMain(): sub-bin
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |        0 |        0 |        0 |        0 |                   |
----------|----------|----------|----------|----------|-------------------|
```

This demonstrates the singleton issue by which the value written to `singleton-lib.js` by nyc is seen by `singleton-bin.js` at startup, then the new value is seen by nyc after singleton-bin.js exits.

Then run `CLEAR_IT=1 ./bin/nyc.js node ./singleton-bin.js` to activate the singleton workaround:
```
bin/wrap.js before sw.runMain(): bin/wrap.js
start singleton-bin.js: undefined
singleton-bin.js wrote: sub-bin
bin/wrap.js after sw.runMain(): bin/wrap.js
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |        0 |        0 |        0 |        0 |                   |
----------|----------|----------|----------|----------|-------------------|
```

This shows that when you clear `require.cache` singleton-bin.js doesn't see the value set by nyc and nyc doesn't see the value set by singleton-bin.js.

In theory `spawn-wrap` should just completely clear `require.cache` instead of just removing the script to be run:
https://github.com/tapjs/spawn-wrap/blob/7931ab5ca8732468efb115fc23b89cd7d96c5550/index.js#L445

CC @bcoe