### PR TITLE
Revert "fix: Exclude negated not working with '--all' switch"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ test/build/
 *.covered.js
 *.swp
 needs-transpile.js
-
-!*test/fixtures/cli/include-exclude/node_modules/

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 /* global __coverage__ */
 
-const arrayUniq = require('array-uniq')
 const arrify = require('arrify')
 const cachingTransform = require('caching-transform')
 const util = require('util')
@@ -248,20 +247,16 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
 }
 
 NYC.prototype.walkAllFiles = function (dir, visitor) {
-  const pattern = (this.extensions.length === 1)
-    ? `**/*${this.extensions[0]}`
-    : `**/*{${this.extensions.join()}}`
+  var pattern = null
+  if (this.extensions.length === 1) {
+    pattern = '**/*' + this.extensions[0]
+  } else {
+    pattern = '**/*{' + this.extensions.join() + '}'
+  }
 
-  let filesToWalk = glob.sync(pattern, { cwd: dir, nodir: true, ignore: this.exclude.exclude })
-
-  // package node-glob no longer observes negated excludes, so we need to restore these files ourselves
-  const excludeNegatedPaths = this.exclude.excludeNegated
-  excludeNegatedPaths.forEach(pattern => {
-    filesToWalk = filesToWalk.concat(glob.sync(pattern, { cwd: dir, nodir: true }))
+  glob.sync(pattern, { cwd: dir, nodir: true, ignore: this.exclude.exclude }).forEach(function (filename) {
+    visitor(filename)
   })
-  filesToWalk = arrayUniq(filesToWalk)
-
-  filesToWalk.forEach(visitor)
 }
 
 NYC.prototype._maybeInstrumentSource = function (code, filename, relFile) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,11 +215,6 @@
         "es-abstract": "^1.7.0"
       }
     },
-    "array-uniq": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-2.0.0.tgz",
-      "integrity": "sha512-O3QZEr+3wDj7otzF7PjNGs6CA3qmYMLvt5xGkjY/V0VxS+ovvqVo/5wKM/OVOAyuX4DTh9H31zE/yKtO66hTkg=="
-    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
   "license": "ISC",
   "dependencies": {
     "archy": "^1.0.0",
-    "array-uniq": "^2.0.0",
     "arrify": "^1.0.1",
     "caching-transform": "^3.0.1",
     "convert-source-map": "^1.6.0",

--- a/test/fixtures/cli/include-exclude/exclude-negated.js
+++ b/test/fixtures/cli/include-exclude/exclude-negated.js
@@ -1,2 +1,0 @@
-'use strict';
-console.log('Hello, World!')

--- a/test/fixtures/cli/include-exclude/excluded.js
+++ b/test/fixtures/cli/include-exclude/excluded.js
@@ -1,2 +1,0 @@
-'use strict';
-console.log('Hello, World!')

--- a/test/fixtures/cli/include-exclude/node_modules/cover-me.js
+++ b/test/fixtures/cli/include-exclude/node_modules/cover-me.js
@@ -1,2 +1,0 @@
-'use strict';
-console.log('Hello, World!')

--- a/test/nyc-bin.js
+++ b/test/nyc-bin.js
@@ -101,48 +101,6 @@ describe('the nyc cli', function () {
         done()
       })
     })
-
-    it('should allow negated exclude patterns', function (done) {
-      const args = [bin, '--all', '--exclude', '**/include-exclude/**', '--exclude', '!**/exclude-negated.js', process.execPath, './half-covered.js']
-
-      const proc = spawn(process.execPath, args, {
-        cwd: fixturesCLI,
-        env: env
-      })
-
-      let stdout = ''
-      proc.stdout.on('data', chunk => {
-        stdout += chunk
-      })
-
-      proc.on('close', code => {
-        code.should.equal(0)
-        stdout.should.not.match(/excluded\.js/)
-        stdout.should.match(/exclude-negated\.js/)
-        done()
-      })
-    })
-
-    it('should include \'node_modules\' using exclude patterns', function (done) {
-      const args = [bin, '--all', '--exclude', '!**/node_modules/**', process.execPath, './half-covered.js']
-
-      const proc = spawn(process.execPath, args, {
-        cwd: fixturesCLI,
-        env: env
-      })
-
-      let stdout = ''
-      proc.stdout.on('data', chunk => {
-        stdout += chunk
-      })
-
-      proc.on('close', code => {
-        code.should.equal(0)
-        stdout.should.match(/include-exclude\/node_modules/)
-        stdout.should.match(/cover-me\.js/)
-        done()
-      })
-    })
   })
 
   describe('--ignore-class-method', function () {


### PR DESCRIPTION
Reverts istanbuljs/nyc#977

---

@AndrewFinlay we need to revert for now.  After istanbuljs/istanbuljs#307 is merged we should be able to make this happen from the `test-exclude` side.