### PR TITLE
feat: add `es-modules` option to instrument command

### DIFF
--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -51,6 +51,11 @@ exports.builder = function (yargs) {
       type: 'boolean',
       description: 'should nyc exit when an instrumentation failure occurs?'
     })
+    .option('es-modules', {
+      default: true,
+      type: 'boolean',
+      description: 'tell the instrumenter to treat files as ES Modules'
+    })
     .example('$0 instrument ./lib ./output', 'instrument all .js files in ./lib with coverage and output in ./output')
 }
 
@@ -68,6 +73,7 @@ exports.handler = function (argv) {
     require: argv.require,
     compact: argv.compact,
     preserveComments: argv.preserveComments,
+    esModules: argv.esModules,
     exitOnError: argv.exitOnError
   })
 


### PR DESCRIPTION
This is pretty straightforward, allow the es-modules option to flow through to the instrumenter when running the standalone instrument command.

Tests adapted from the existing tests for the regular es-modules command.