### PR TITLE
feat: Fix excludeAfterRemap functionality.

### DIFF
--- a/index.js
+++ b/index.js
@@ -415,22 +415,22 @@ function coverageFinder () {
 }
 
 NYC.prototype.getCoverageMapFromAllCoverageFiles = function (baseDirectory) {
-  var _this = this
   var map = libCoverage.createCoverageMap({})
 
   this.eachReport(undefined, (report) => {
     map.merge(report)
   }, baseDirectory)
+
+  map.data = this.sourceMaps.remapCoverage(map.data)
+
   // depending on whether source-code is pre-instrumented
   // or instrumented using a JIT plugin like @babel/require
   // you may opt to exclude files after applying
   // source-map remapping logic.
   if (this.config.excludeAfterRemap) {
-    map.filter(function (filename) {
-      return _this.exclude.shouldInstrument(filename)
-    })
+    map.filter(filename => this.exclude.shouldInstrument(filename))
   }
-  map.data = this.sourceMaps.remapCoverage(map.data)
+
   return map
 }
 

--- a/lib/commands/check-coverage.js
+++ b/lib/commands/check-coverage.js
@@ -1,3 +1,4 @@
+const testExclude = require('test-exclude')
 const NYC = require('../../index.js')
 
 exports.command = 'check-coverage'
@@ -6,6 +7,24 @@ exports.describe = 'check whether coverage is within thresholds provided'
 
 exports.builder = function (yargs) {
   yargs
+    .option('exclude', {
+      alias: 'x',
+      default: testExclude.defaultExclude,
+      describe: 'a list of specific files and directories that should be excluded from coverage, glob patterns are supported, node_modules is always excluded',
+      global: false
+    })
+    .option('exclude-after-remap', {
+      default: true,
+      type: 'boolean',
+      description: 'should exclude logic be performed after the source-map remaps filenames?',
+      global: false
+    })
+    .option('include', {
+      alias: 'n',
+      default: [],
+      describe: 'a list of specific files that should be covered, glob patterns are supported',
+      global: false
+    })
     .option('branches', {
       default: 0,
       description: 'what % of branches must be covered?'

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -1,3 +1,4 @@
+const testExclude = require('test-exclude')
 const NYC = require('../../index.js')
 
 exports.command = 'report'
@@ -22,6 +23,24 @@ exports.builder = function (yargs) {
     })
     .option('temp-directory', {
       hidden: true
+    })
+    .option('exclude', {
+      alias: 'x',
+      default: testExclude.defaultExclude,
+      describe: 'a list of specific files and directories that should be excluded from coverage, glob patterns are supported, node_modules is always excluded',
+      global: false
+    })
+    .option('exclude-after-remap', {
+      default: true,
+      type: 'boolean',
+      description: 'should exclude logic be performed after the source-map remaps filenames?',
+      global: false
+    })
+    .option('include', {
+      alias: 'n',
+      default: [],
+      describe: 'a list of specific files that should be covered, glob patterns are supported',
+      global: false
     })
     .option('show-process-tree', {
       describe: 'display the tree of spawned processes',

--- a/package-lock.json
+++ b/package-lock.json
@@ -189,6 +189,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -945,11 +946,6 @@
         "array-ify": "^1.0.0",
         "dot-prop": "^3.0.0"
       }
-    },
-    "compare-versions": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.4.0.tgz",
-      "integrity": "sha512-tK69D7oNXXqUW3ZNo/z7NXTEz22TCF0pTE+YF9cxvaAM9XnkLo1fV621xCLrRR6aevJlKxExkss0vWqUCUpqdg=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -2172,7 +2168,8 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -2295,15 +2292,6 @@
       "requires": {
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
-      }
-    },
-    "fileset": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
-      "integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
-      "requires": {
-        "glob": "^7.0.3",
-        "minimatch": "^3.0.3"
       }
     },
     "find-cache-dir": {
@@ -3003,26 +2991,6 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
-    "istanbul-api": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.1.tgz",
-      "integrity": "sha512-kVmYrehiwyeBAk/wE71tW6emzLiHGjYIiDrc8sfyty4F8M02/lrgXSm+R1kXysmF20zArvmZXjlE/mg24TVPJw==",
-      "requires": {
-        "async": "^2.6.1",
-        "compare-versions": "^3.2.1",
-        "fileset": "^2.0.3",
-        "istanbul-lib-coverage": "^2.0.3",
-        "istanbul-lib-hook": "^2.0.3",
-        "istanbul-lib-instrument": "^3.1.0",
-        "istanbul-lib-report": "^2.0.4",
-        "istanbul-lib-source-maps": "^3.0.2",
-        "istanbul-reports": "^2.1.1",
-        "js-yaml": "^3.12.0",
-        "make-dir": "^1.3.0",
-        "minimatch": "^3.0.4",
-        "once": "^1.4.0"
-      }
-    },
     "istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -3106,6 +3074,7 @@
       "version": "3.12.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.1.tgz",
       "integrity": "sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -5338,7 +5307,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "find-up": "^3.0.0",
     "foreground-child": "^1.5.6",
     "glob": "^7.1.3",
-    "istanbul-api": "^2.1.0",
     "istanbul-lib-coverage": "^2.0.3",
     "istanbul-lib-hook": "^2.0.3",
     "istanbul-lib-instrument": "^3.1.0",

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -1043,6 +1043,39 @@ describe('the nyc cli', function () {
           done()
         })
       })
+
+      it('uses source-maps to exclude original sources from reports', (done) => {
+        const args = [
+          bin,
+          '--all',
+          '--cache', 'false',
+          '--exclude', 'original/s1.js',
+          process.execPath, './instrumented/s1.min.js'
+        ]
+
+        const proc = spawn(process.execPath, args, {
+          cwd: fixturesSourceMaps,
+          env: env
+        })
+
+        var stdout = ''
+        proc.stdout.on('data', function (chunk) {
+          stdout += chunk
+        })
+
+        proc.on('close', function (code) {
+          code.should.equal(0)
+          stdoutShouldEqual(stdout, `
+            ----------|----------|----------|----------|----------|-------------------|
+            File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+            ----------|----------|----------|----------|----------|-------------------|
+            All files |        0 |      100 |        0 |        0 |                   |
+             s2.js    |        0 |      100 |        0 |        0 |           1,2,4,6 |
+            ----------|----------|----------|----------|----------|-------------------|`
+          )
+          done()
+        })
+      })
     })
 
     describe('.map file', () => {


### PR DESCRIPTION
I'm not sure if this qualifies as a feature or a fix, filtering after remapping has never worked.  Original implementation of filtering remapped sources at dd40dc51, addition of excludeAfterRemap option at cdfdff36.  Unfortunately the filtering step was done before coverage was remapped using source-maps, so it didn't do anything.

This is a potentially breaking change - bundled / compiled code was never filtered based on the original source filename, after this it will be.  As an auxiliary change `test-exclude` options are also added to the `nyc report` and `nyc check-coverage` as those commands should process exclude-after-remap.

Fixes #956