### PR TITLE
chore: Fix es-module test to check for absolute file path in error.

### DIFF
--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -640,7 +640,7 @@ describe('the nyc cli', function () {
           proc.on('close', function (code) {
             code.should.equal(1)
             stdoutShouldEqual(stderr, `
-              Failed to instrument ./not-strict.js`)
+              Failed to instrument ${path.resolve(fixturesCLI, 'not-strict.js')}`)
             const subdirExists = fs.existsSync(path.resolve(fixturesCLI, './output'))
             subdirExists.should.equal(false)
             done()


### PR DESCRIPTION
CI runs between #1012 and #1006 got crossed.