### PR TITLE
chore: update instrument code to use es2015+

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,13 +216,12 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
     if (stats.isDirectory()) {
       this.walkAllFiles(input, visitor)
     } else {
-      const inputPath = path.resolve('.', input)
-      visitor(inputPath, path.basename(input))
+      visitor(path.resolve(input), path.basename(input))
     }
   } catch (err) {
     return cb(err)
   }
-  return cb()
+  cb()
 }
 
 NYC.prototype.walkAllFiles = function (dir, visitor) {

--- a/index.js
+++ b/index.js
@@ -191,48 +191,40 @@ NYC.prototype.addAllFiles = function () {
 }
 
 NYC.prototype.instrumentAllFiles = function (input, output, cb) {
-  var _this = this
-  var inputDir = '.' + path.sep
-  var visitor = function (filename) {
-    var ext
-    var transform
-    var inFile = path.resolve(inputDir, filename)
-    var code = fs.readFileSync(inFile, 'utf-8')
+  const visitor = (filename, singleFile = false) => {
+    const inputPath = path.resolve(this.cwd, input, filename)
+    const inCode = fs.readFileSync(inputPath, 'utf-8')
 
-    for (ext in _this.transforms) {
-      if (filename.toLowerCase().substr(-ext.length) === ext) {
-        transform = _this.transforms[ext]
-        break
-      }
-    }
+    const extname = path.extname(filename).toLowerCase()
+    const transform = this.transforms[extname] || false
+    const outCode = (transform)
+      ? transform(inCode, { filename: `./${path.relative(this.cwd, inputPath)}` })
+      : inCode
 
-    if (transform) {
-      code = transform(code, { filename: inFile, relFile: inFile })
-    }
-
-    if (!output) {
-      console.log(code)
+    if (output) {
+      const subpath = singleFile || path.relative(input, path.resolve(input, filename))
+      const outputPath = path.resolve(this.cwd, output, subpath)
+      mkdirp.sync(path.dirname(outputPath))
+      fs.writeFileSync(outputPath, outCode, 'utf-8')
     } else {
-      var outFile = path.resolve(output, filename)
-      mkdirp.sync(path.dirname(outFile))
-      fs.writeFileSync(outFile, code, 'utf-8')
+      console.log(outCode)
     }
   }
 
   this._loadAdditionalModules()
 
   try {
-    var stats = fs.lstatSync(input)
+    const inputPath = path.resolve(this.cwd, input)
+    const stats = fs.lstatSync(inputPath)
     if (stats.isDirectory()) {
-      inputDir = input
-      this.walkAllFiles(input, visitor)
+      this.walkAllFiles(inputPath, visitor)
     } else {
-      visitor(input)
+      visitor(inputPath, path.basename(inputPath))
     }
   } catch (err) {
     return cb(err)
   }
-  cb()
+  return cb()
 }
 
 NYC.prototype.walkAllFiles = function (dir, visitor) {

--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
     if (stats.isDirectory()) {
       this.walkAllFiles(input, visitor)
     } else {
-      visitor(path.resolve(input), path.basename(input))
+      visitor(path.resolve(input), input)
     }
   } catch (err) {
     return cb(err)

--- a/index.js
+++ b/index.js
@@ -191,8 +191,9 @@ NYC.prototype.addAllFiles = function () {
 }
 
 NYC.prototype.instrumentAllFiles = function (input, output, cb) {
-  const visitor = (filename, singleFile = false) => {
-    const inFile = path.resolve(input, filename)
+  let inputDir = '.' + path.sep
+  const visitor = filename => {
+    const inFile = path.resolve(inputDir, filename)
     const inCode = fs.readFileSync(inFile, 'utf-8')
 
     const extname = path.extname(filename).toLowerCase()
@@ -200,8 +201,7 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
     const outCode = transform(inCode, { filename: inFile })
 
     if (output) {
-      const subPath = singleFile || path.relative(input, path.resolve(input, filename))
-      const outFile = path.resolve(output, subPath)
+      const outFile = path.resolve(output, filename)
       mkdirp.sync(path.dirname(outFile))
       fs.writeFileSync(outFile, outCode, 'utf-8')
     } else {
@@ -214,9 +214,10 @@ NYC.prototype.instrumentAllFiles = function (input, output, cb) {
   try {
     const stats = fs.lstatSync(input)
     if (stats.isDirectory()) {
+      inputDir = input
       this.walkAllFiles(input, visitor)
     } else {
-      visitor(path.resolve(input), input)
+      visitor(input)
     }
   } catch (err) {
     return cb(err)

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -62,12 +62,12 @@ exports.builder = function (yargs) {
 }
 
 exports.handler = function (argv) {
-  // if instrument is set to false,
-  // enable a noop instrumenter.
-  if (!argv.instrument) argv.instrumenter = './lib/instrumenters/noop'
-  else argv.instrumenter = './lib/instrumenters/istanbul'
+  // If instrument is set to false enable a noop instrumenter.
+  argv.instrumenter = (!argv.instrument)
+    ? './lib/instrumenters/noop'
+    : './lib/instrumenters/istanbul'
 
-  var nyc = new NYC({
+  const nyc = new NYC({
     instrumenter: argv.instrumenter,
     sourceMap: argv.sourceMap,
     produceSourceMap: argv.produceSourceMap,
@@ -89,12 +89,10 @@ exports.handler = function (argv) {
     }
   }
 
-  nyc.instrumentAllFiles(argv.input, argv.output, function (err) {
+  nyc.instrumentAllFiles(argv.input, argv.output, err => {
     if (err) {
       console.error(err.message)
-      process.exit(1)
-    } else {
-      process.exit(0)
+      process.exitCode = 1
     }
   })
 }

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -63,9 +63,9 @@ exports.builder = function (yargs) {
 
 exports.handler = function (argv) {
   // If instrument is set to false enable a noop instrumenter.
-  argv.instrumenter = (!argv.instrument)
-    ? './lib/instrumenters/noop'
-    : './lib/instrumenters/istanbul'
+  argv.instrumenter = (argv.instrument)
+    ? './lib/instrumenters/istanbul'
+    : './lib/instrumenters/noop'
 
   const nyc = new NYC({
     instrumenter: argv.instrumenter,

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -581,7 +581,9 @@ describe('the nyc cli', function () {
           done()
         })
       })
+    })
 
+    describe('output folder specified', function () {
       it('works in directories without a package.json', function (done) {
         var args = [bin, 'instrument', './input-dir', './output-dir']
 
@@ -619,12 +621,6 @@ describe('the nyc cli', function () {
           code.should.equal(1)
           done()
         })
-      })
-    })
-
-    describe('output folder specified', function () {
-      afterEach(function () {
-        rimraf.sync(path.resolve(fixturesCLI, 'output'))
       })
 
       it('allows a single file to be instrumented', function (done) {

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -589,7 +589,7 @@ describe('the nyc cli', function () {
       })
 
       it('works in directories without a package.json', function (done) {
-        var args = [bin, 'instrument', './input-dir', '../output']
+        var args = [bin, 'instrument', './input-dir', './output-dir']
 
         var subdir = path.resolve(fixturesCLI, 'subdir')
         var proc = spawn(process.execPath, args, {
@@ -599,7 +599,7 @@ describe('the nyc cli', function () {
 
         proc.on('exit', function (code) {
           code.should.equal(0)
-          var target = path.resolve(subdir, '../output', 'index.js')
+          var target = path.resolve(subdir, 'output-dir', 'index.js')
           fs.readFileSync(target, 'utf8')
             .should.match(/console.log\('Hello, World!'\)/)
           done()
@@ -612,7 +612,7 @@ describe('the nyc cli', function () {
           'instrument',
           '--exit-on-error',
           './input-dir',
-          '../output'
+          './output-dir'
         ]
 
         var subdir = path.resolve(fixturesCLI, 'subdir')

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -584,6 +584,10 @@ describe('the nyc cli', function () {
     })
 
     describe('output folder specified', function () {
+      afterEach(function () {
+        rimraf.sync(path.resolve(fixturesCLI, 'output'))
+      })
+
       it('works in directories without a package.json', function (done) {
         var args = [bin, 'instrument', './input-dir', './output-dir']
 

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -589,7 +589,7 @@ describe('the nyc cli', function () {
       })
 
       it('works in directories without a package.json', function (done) {
-        var args = [bin, 'instrument', './input-dir', './output-dir']
+        var args = [bin, 'instrument', './input-dir', '../output']
 
         var subdir = path.resolve(fixturesCLI, 'subdir')
         var proc = spawn(process.execPath, args, {
@@ -599,7 +599,7 @@ describe('the nyc cli', function () {
 
         proc.on('exit', function (code) {
           code.should.equal(0)
-          var target = path.resolve(subdir, 'output-dir', 'index.js')
+          var target = path.resolve(subdir, '../output', 'index.js')
           fs.readFileSync(target, 'utf8')
             .should.match(/console.log\('Hello, World!'\)/)
           done()
@@ -612,7 +612,7 @@ describe('the nyc cli', function () {
           'instrument',
           '--exit-on-error',
           './input-dir',
-          './output-dir'
+          '../output'
         ]
 
         var subdir = path.resolve(fixturesCLI, 'subdir')


### PR DESCRIPTION
This is an attempt to use some more modern language features in the `instrument.js` and the `instrumentAllFiles` command.  It's a cut back version of what I was proposing in #1003 as per conversation with @coreyfarrell.

As there's quite a bit here I'll drop in some notes and assumptions
* Notes:
1. Refactor `nyc-integration` instrument tests so tests with output folder specified aren't in the no output folder suite
2. Refactor `instrument.js` and `instrumentAllFiles` command to use modern javascript
3. Remove call to deprecated `process.exit()` in instrument command
4. Removed unused transform metadata param `relFile`, _this is an issue in other parts of the code_.
5. Use file extension as an index to find the correct transform, rather than trying to match a transform name to the rightmost characters of a filename, _this may be an issue in other parts of the code_.

* Assumptions:
1. That we want to use file extensions to find transforms, the existing implementation would use the `.js` instrumenter for both `.js` and `.mjs` files, these changes assume that was wrong.
2. When `instrumentAllFiles` fails to find the correct transform, it returns the uninstrumented source,
3. It looks like the `relFile` property isn't used anymore, so I'm assuming it can be safely removed