### PR TITLE
feat: add `--build-process-tree` feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function NYC (config) {
   this._reportDir = config.reportDir || 'coverage'
   this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true
   this._showProcessTree = config.showProcessTree || false
+  this._buildProcessTree = this._showProcessTree || config.buildProcessTree
   this._eagerInstantiation = config.eager || false
   this.cwd = config.cwd || process.cwd()
   this.reporter = arrify(config.reporter || 'text')
@@ -325,7 +326,7 @@ NYC.prototype.createTempDirectory = function () {
   mkdirp.sync(this.tempDirectory())
   if (this.cache) mkdirp.sync(this.cacheDirectory)
 
-  if (this._showProcessTree) {
+  if (this._buildProcessTree) {
     mkdirp.sync(this.processInfoDirectory())
   }
 }
@@ -384,7 +385,7 @@ NYC.prototype.writeCoverageFile = function () {
     'utf-8'
   )
 
-  if (!this._showProcessTree) {
+  if (!this._buildProcessTree) {
     return
   }
 

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -224,6 +224,12 @@ Config.buildYargs = function (cwd) {
       type: 'boolean',
       global: false
     })
+    .option('build-process-tree', {
+      describe: 'create files for the tree of spawned processes',
+      default: false,
+      type: 'boolean',
+      global: false
+    })
     .option('clean', {
       describe: 'should the .nyc_output folder be cleaned before executing tests',
       default: true,

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -935,6 +935,47 @@ describe('the nyc cli', function () {
     })
   })
 
+  describe('--build-process-tree', function () {
+    it('builds, but does not display, a tree of spawned processes', function (done) {
+      var args = [bin, '--build-process-tree', process.execPath, 'selfspawn-fibonacci.js', '5']
+
+      var proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      var stdout = ''
+      proc.stdout.setEncoding('utf8')
+      proc.stdout.on('data', function (chunk) {
+        stdout += chunk
+      })
+
+      proc.on('close', function (code) {
+        code.should.equal(0)
+        stdout.should.not.match(new RegExp('└─'))
+        fs.statSync(path.resolve(fixturesCLI, '.nyc_output', 'processinfo'))
+        done()
+      })
+    })
+
+    it('doesn’t create the temp directory for process info files when not present', function (done) {
+      var args = [bin, process.execPath, 'selfspawn-fibonacci.js', '5']
+
+      var proc = spawn(process.execPath, args, {
+        cwd: fixturesCLI,
+        env: env
+      })
+
+      proc.on('exit', function (code) {
+        code.should.equal(0)
+        fs.stat(path.resolve(fixturesCLI, '.nyc_output', 'processinfo'), function (err, stat) {
+          err.code.should.equal('ENOENT')
+          done()
+        })
+      })
+    })
+  })
+
   describe('--temp-dir', function () {
     beforeEach(() => {
       rimraf.sync(path.resolve(fixturesCLI, '.nyc_output'))


### PR DESCRIPTION
This allows a user to build the processinfo temp files, without actually
dumping the process tree to stdout.

The goal is to use this in node-tap to see which processes covered which
files, so we know which tests to re-run on changes to the source files.