### PR TITLE
feat: Rename `plugins` option to `parser-plugins`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ NYC.prototype._createInstrumenter = function () {
     compact: this.config.compact,
     preserveComments: this.config.preserveComments,
     esModules: this.config.esModules,
-    plugins: this.config.plugins
+    plugins: this.config.parserPlugins
   })
 }
 

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -7,7 +7,7 @@ function getInvalidatingOptions (config) {
     'ignoreClassMethods',
     'instrument',
     'instrumenter',
-    'plugins',
+    'parserPlugins',
     'preserveComments',
     'produceSourceMap',
     'sourceMap'

--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -5,7 +5,7 @@ const convertSourceMap = require('convert-source-map')
 const mergeSourceMap = require('merge-source-map')
 
 function InstrumenterIstanbul (cwd, options) {
-  const plugins = options.plugins
+  const plugins = options.parserPlugins
   const configPlugins = plugins ? { plugins } : {}
 
   const instrumenter = createInstrumenter(Object.assign({


### PR DESCRIPTION
The original option name created confusion about what was expected.
This helps identify that babel parser plugins are expected, not babel
transform plugins.

BREAKING CHANGE: The `plugins` option has been renamed to
`parser-plugins`.

Fixes #986