### PR TITLE
fix: make --all work for transpiled code

### DIFF
--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -4,12 +4,12 @@ const libSourceMaps = require('istanbul-lib-source-maps')
 const fs = require('fs')
 const path = require('path')
 
-// TODO: write some unit tests for this class.
+let sourceMapCache = libSourceMaps.createSourceMapStore()
 function SourceMaps (opts) {
   this.cache = opts.cache
   this.cacheDirectory = opts.cacheDirectory
-  this.sourceMapCache = libSourceMaps.createSourceMapStore()
   this.loadedMaps = {}
+  this._sourceMapCache = sourceMapCache
 }
 
 SourceMaps.prototype.extractAndRegister = function (code, filename, hash) {
@@ -19,14 +19,14 @@ SourceMaps.prototype.extractAndRegister = function (code, filename, hash) {
       var mapPath = path.join(this.cacheDirectory, hash + '.map')
       fs.writeFileSync(mapPath, sourceMap.toJSON())
     } else {
-      this.sourceMapCache.registerMap(filename, sourceMap.sourcemap)
+      this._sourceMapCache.registerMap(filename, sourceMap.sourcemap)
     }
   }
   return sourceMap
 }
 
 SourceMaps.prototype.remapCoverage = function (obj) {
-  var transformed = this.sourceMapCache.transformCoverage(
+  var transformed = this._sourceMapCache.transformCoverage(
     libCoverage.createCoverageMap(obj)
   )
   return transformed.map.data
@@ -34,7 +34,7 @@ SourceMaps.prototype.remapCoverage = function (obj) {
 
 SourceMaps.prototype.reloadCachedSourceMaps = function (report) {
   var _this = this
-  Object.keys(report).forEach(function (absFile) {
+  Object.keys(report).forEach((absFile) => {
     var fileReport = report[absFile]
     if (fileReport && fileReport.contentHash) {
       var hash = fileReport.contentHash
@@ -48,7 +48,7 @@ SourceMaps.prototype.reloadCachedSourceMaps = function (report) {
         }
       }
       if (_this.loadedMaps[hash]) {
-        _this.sourceMapCache.registerMap(absFile, _this.loadedMaps[hash])
+        this._sourceMapCache.registerMap(absFile, _this.loadedMaps[hash])
       }
     }
   })

--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -4,7 +4,7 @@ const libSourceMaps = require('istanbul-lib-source-maps')
 const fs = require('fs')
 const path = require('path')
 
-let sourceMapCache = libSourceMaps.createSourceMapStore()
+const sourceMapCache = libSourceMaps.createSourceMapStore()
 function SourceMaps (opts) {
   this.cache = opts.cache
   this.cacheDirectory = opts.cacheDirectory
@@ -33,22 +33,21 @@ SourceMaps.prototype.remapCoverage = function (obj) {
 }
 
 SourceMaps.prototype.reloadCachedSourceMaps = function (report) {
-  var _this = this
   Object.keys(report).forEach((absFile) => {
     var fileReport = report[absFile]
     if (fileReport && fileReport.contentHash) {
       var hash = fileReport.contentHash
-      if (!(hash in _this.loadedMaps)) {
+      if (!(hash in this.loadedMaps)) {
         try {
-          var mapPath = path.join(_this.cacheDirectory, hash + '.map')
-          _this.loadedMaps[hash] = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
+          var mapPath = path.join(this.cacheDirectory, hash + '.map')
+          this.loadedMaps[hash] = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
         } catch (e) {
           // set to false to avoid repeatedly trying to load the map
-          _this.loadedMaps[hash] = false
+          this.loadedMaps[hash] = false
         }
       }
-      if (_this.loadedMaps[hash]) {
-        this._sourceMapCache.registerMap(absFile, _this.loadedMaps[hash])
+      if (this.loadedMaps[hash]) {
+        this._sourceMapCache.registerMap(absFile, this.loadedMaps[hash])
       }
     }
   })

--- a/test/source-maps.js
+++ b/test/source-maps.js
@@ -1,0 +1,20 @@
+/* global describe, it */
+
+require('chai').should()
+require('tap').mochaGlobals()
+
+const { readFileSync } = require('fs')
+const SourceMaps = require('../self-coverage/lib/source-maps')
+
+describe('source-maps', function () {
+  it('caches source maps globally', function () {
+    const sm = new SourceMaps({})
+    // load a source map into cache.
+    const sourceFile = require.resolve('./fixtures/source-maps/instrumented/s1.min.js')
+    sm.extractAndRegister(readFileSync(sourceFile, 'utf8'), sourceFile, 'abc123')
+    // create a new SourceMaps instance.
+    const sm2 = new SourceMaps({})
+    // the two instances of SourceMaps should share a cache.
+    sm._sourceMapCache.should.deep.equal(sm2._sourceMapCache)
+  })
+})


### PR DESCRIPTION
during normal operation nyc will instantiate SourceMaps multiple times:

* once during initial instrumentation/execution step.
* once when reporting takes place.

Because `--all`  does not save source-maps to cache (as is the case when files are loaded during normal execution) the source-maps extracted by `--all` are dropped on the floor and never used.

This tiny fix makes source-maps start working in conjunction with `--all`.