### PR TITLE
feat: add processinfo index, add externalId

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -65,6 +65,10 @@ if ([
   ), function (done) {
     var mainChildExitCode = process.exitCode
 
+    if (argv.showProcessTree || argv.buildProcessTree) {
+      nyc.writeProcessIndex()
+    }
+
     if (argv.checkCoverage) {
       nyc.checkCoverage({
         lines: argv.lines,

--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -8,6 +8,7 @@ config.isChildProcess = true
 config._processInfo = {
   pid: process.pid,
   ppid: process.ppid,
+  parent: process.env.NYC_PROCESS_ID,
   root: process.env.NYC_ROOT_ID
 }
 if (process.env.NYC_PROCESSINFO_EXTERNAL_ID) {

--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -8,7 +8,7 @@ config.isChildProcess = true
 config._processInfo = {
   pid: process.pid,
   ppid: process.ppid,
-  parent: process.env.NYC_PROCESS_ID,
+  parent: process.env.NYC_PROCESS_ID || null,
   root: process.env.NYC_ROOT_ID
 }
 if (process.env.NYC_PROCESSINFO_EXTERNAL_ID) {

--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -10,6 +10,10 @@ config._processInfo = {
   ppid: process.ppid,
   root: process.env.NYC_ROOT_ID
 }
+if (process.env.NYC_PROCESSINFO_EXTERNAL_ID) {
+  config._processInfo.externalId = process.env.NYC_PROCESSINFO_EXTERNAL_ID
+  delete process.env.NYC_PROCESSINFO_EXTERNAL_ID
+}
 
 ;(new NYC(config)).wrap()
 

--- a/index.js
+++ b/index.js
@@ -469,7 +469,7 @@ NYC.prototype.writeProcessIndex = function () {
         children: info.children
       }
     }
-    index.processes[info.uuid].children = Array.from(info.children || [])
+    index.processes[info.uuid].children = Array.from(info.children)
     return index
   }, { processes: {}, files: files, externalIds: {} })
 

--- a/lib/process.js
+++ b/lib/process.js
@@ -13,6 +13,7 @@ function ProcessInfo (defaults) {
   this.root = null
   this.coverageFilename = null
   this.nodes = [] // list of children, filled by buildProcessTree()
+  this.children = [] // just uuids, not full nodes
 
   this._coverageMap = null
 

--- a/lib/process.js
+++ b/lib/process.js
@@ -1,9 +1,12 @@
 const archy = require('archy')
 const libCoverage = require('istanbul-lib-coverage')
+const uuid = require('uuid/v4')
 
 function ProcessInfo (defaults) {
   defaults = defaults || {}
 
+  this.uuid = null
+  this.parent = null
   this.pid = String(process.pid)
   this.argv = process.argv
   this.execArgv = process.execArgv
@@ -12,13 +15,13 @@ function ProcessInfo (defaults) {
   this.ppid = null
   this.root = null
   this.coverageFilename = null
-  this.nodes = [] // list of children, filled by buildProcessTree()
-  this.children = [] // just uuids, not full nodes
-
-  this._coverageMap = null
 
   for (var key in defaults) {
     this[key] = defaults[key]
+  }
+
+  if (!this.uuid) {
+    this.uuid = uuid()
   }
 }
 
@@ -37,7 +40,7 @@ Object.defineProperty(ProcessInfo.prototype, 'label', {
 })
 
 ProcessInfo.buildProcessTree = function (infos) {
-  var treeRoot = new ProcessInfo({ _label: 'nyc' })
+  var treeRoot = new ProcessInfo({ _label: 'nyc', nodes: [] })
   var nodes = { }
 
   infos = infos.sort(function (a, b) {
@@ -45,6 +48,7 @@ ProcessInfo.buildProcessTree = function (infos) {
   })
 
   infos.forEach(function (p) {
+    p.nodes = []
     nodes[p.root + ':' + p.pid] = p
   })
 

--- a/lib/process.js
+++ b/lib/process.js
@@ -48,7 +48,7 @@ ProcessInfo.buildProcessTree = function (infos) {
       throw new Error(`Invalid entry in processinfo index: ${id}`)
     }
     const idx = index.processes[id]
-    node.nodes = idx.children.map(id => infos[id])
+    node.nodes = idx.children.map(id => infos[id]).sort((a, b) => a.time - b.time)
     if (!node.parent) {
       treeRoot.nodes.push(node)
     }

--- a/lib/process.js
+++ b/lib/process.js
@@ -40,30 +40,19 @@ Object.defineProperty(ProcessInfo.prototype, 'label', {
 })
 
 ProcessInfo.buildProcessTree = function (infos) {
-  var treeRoot = new ProcessInfo({ _label: 'nyc', nodes: [] })
-  var nodes = { }
-
-  infos = infos.sort(function (a, b) {
-    return a.time - b.time
-  })
-
-  infos.forEach(function (p) {
-    p.nodes = []
-    nodes[p.root + ':' + p.pid] = p
-  })
-
-  infos.forEach(function (p) {
-    if (!p.ppid) {
-      return
+  const treeRoot = new ProcessInfo({ _label: 'nyc', nodes: [] })
+  const index = infos.index
+  for (const id in index.processes) {
+    const node = infos[id]
+    if (!node) {
+      throw new Error(`Invalid entry in processinfo index: ${id}`)
     }
-
-    var parent = nodes[p.root + ':' + p.ppid]
-    if (!parent) {
-      parent = treeRoot
+    const idx = index.processes[id]
+    node.nodes = idx.children.map(id => infos[id])
+    if (!node.parent) {
+      treeRoot.nodes.push(node)
     }
-
-    parent.nodes.push(p)
-  })
+  }
 
   return treeRoot
 }

--- a/test/processinfo.js
+++ b/test/processinfo.js
@@ -52,8 +52,8 @@ t.test('validate the created processinfo data', t => {
           throw er
         const procInfoData = JSON.parse(procInfoJson)
         t.match(procInfoData, {
-          pid: /^[0-9]+$/,
-          ppid: /^[0-9]+$/,
+          pid: Number,
+          ppid: Number,
           uuid: f.replace(/\.json$/, ''),
           argv: [
             node,
@@ -65,10 +65,7 @@ t.test('validate the created processinfo data', t => {
           time: Number,
           root: /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/,
           coverageFilename: resolve(fixturesCLI, tmp, f),
-          nodes: [],
-          _coverageMap: null,
           files: [ resolvedJS ],
-          children: Array,
         })
       })
     })

--- a/test/processinfo.js
+++ b/test/processinfo.js
@@ -1,0 +1,96 @@
+const {resolve} = require('path')
+const bin = resolve(__dirname, '../self-coverage/bin/nyc')
+const {spawn} = require('child_process')
+const t = require('tap')
+const rimraf = require('rimraf')
+const node = process.execPath
+const fixturesCLI = resolve(__dirname, './fixtures/cli')
+const tmp = 'processinfo-test'
+const fs = require('fs')
+const resolvedJS = resolve(fixturesCLI, 'selfspawn-fibonacci.js')
+
+rimraf.sync(resolve(fixturesCLI, tmp))
+t.teardown(() => rimraf.sync(resolve(fixturesCLI, tmp)))
+
+t.test('build some processinfo', t => {
+  var args = [
+    bin, '-t', tmp, '--build-process-tree',
+    node, 'selfspawn-fibonacci.js', '5',
+  ]
+  var proc = spawn(process.execPath, args, {
+    cwd: fixturesCLI,
+    env: {
+      PATH: process.env.PATH,
+      NYC_PROCESSINFO_EXTERNAL_ID: 'blorp',
+    }
+  })
+  // don't actually care about the output for this test, just the data
+  proc.stderr.resume()
+  proc.stdout.resume()
+  proc.on('close', (code, signal) => {
+    t.equal(code, 0)
+    t.equal(signal, null)
+    t.end()
+  })
+})
+
+t.test('validate the created processinfo data', t => {
+  const covs = fs.readdirSync(resolve(fixturesCLI, tmp))
+    .filter(f => f !== 'processinfo')
+  t.plan(covs.length * 2)
+
+  covs.forEach(f => {
+    fs.readFile(resolve(fixturesCLI, tmp, f), 'utf8', (er, covjson) => {
+      if (er)
+        throw er
+      const covdata = JSON.parse(covjson)
+      t.same(Object.keys(covdata), [resolvedJS])
+      // should have matching processinfo for each cov json
+      const procInfoFile = resolve(fixturesCLI, tmp, 'processinfo', f)
+      fs.readFile(procInfoFile, 'utf8', (er, procInfoJson) => {
+        if (er)
+          throw er
+        const procInfoData = JSON.parse(procInfoJson)
+        t.match(procInfoData, {
+          pid: /^[0-9]+$/,
+          ppid: /^[0-9]+$/,
+          uuid: f.replace(/\.json$/, ''),
+          argv: [
+            node,
+            resolvedJS,
+            /[1-5]/,
+          ],
+          execArgv: [],
+          cwd: fixturesCLI,
+          time: Number,
+          root: /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/,
+          coverageFilename: resolve(fixturesCLI, tmp, f),
+          nodes: [],
+          _coverageMap: null,
+          files: [ resolvedJS ],
+          children: Array,
+        })
+      })
+    })
+  })
+})
+
+t.test('check out the index', t => {
+  const indexFile = resolve(fixturesCLI, tmp, 'processinfo', 'index.json')
+  const indexJson = fs.readFileSync(indexFile, 'utf-8')
+  const index = JSON.parse(indexJson)
+  const u = /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/
+  t.match(index, {
+    processes: {},
+    files: {
+      [resolvedJS]: [u, u, u, u, u, u, u, u, u ],
+    },
+    externalIds: {
+      blorp: {
+        root: u,
+        children: [u, u, u, u, u, u, u, u ],
+      },
+    },
+  })
+  t.end()
+})

--- a/test/processinfo.js
+++ b/test/processinfo.js
@@ -1,6 +1,6 @@
-const {resolve} = require('path')
+const { resolve } = require('path')
 const bin = resolve(__dirname, '../self-coverage/bin/nyc')
-const {spawn} = require('child_process')
+const { spawn } = require('child_process')
 const t = require('tap')
 const rimraf = require('rimraf')
 const node = process.execPath
@@ -15,13 +15,13 @@ t.teardown(() => rimraf.sync(resolve(fixturesCLI, tmp)))
 t.test('build some processinfo', t => {
   var args = [
     bin, '-t', tmp, '--build-process-tree',
-    node, 'selfspawn-fibonacci.js', '5',
+    node, 'selfspawn-fibonacci.js', '5'
   ]
   var proc = spawn(process.execPath, args, {
     cwd: fixturesCLI,
     env: {
       PATH: process.env.PATH,
-      NYC_PROCESSINFO_EXTERNAL_ID: 'blorp',
+      NYC_PROCESSINFO_EXTERNAL_ID: 'blorp'
     }
   })
   // don't actually care about the output for this test, just the data
@@ -41,15 +41,17 @@ t.test('validate the created processinfo data', t => {
 
   covs.forEach(f => {
     fs.readFile(resolve(fixturesCLI, tmp, f), 'utf8', (er, covjson) => {
-      if (er)
+      if (er) {
         throw er
+      }
       const covdata = JSON.parse(covjson)
       t.same(Object.keys(covdata), [resolvedJS])
       // should have matching processinfo for each cov json
       const procInfoFile = resolve(fixturesCLI, tmp, 'processinfo', f)
       fs.readFile(procInfoFile, 'utf8', (er, procInfoJson) => {
-        if (er)
+        if (er) {
           throw er
+        }
         const procInfoData = JSON.parse(procInfoJson)
         t.match(procInfoData, {
           pid: Number,
@@ -58,14 +60,14 @@ t.test('validate the created processinfo data', t => {
           argv: [
             node,
             resolvedJS,
-            /[1-5]/,
+            /[1-5]/
           ],
           execArgv: [],
           cwd: fixturesCLI,
           time: Number,
           root: /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/,
           coverageFilename: resolve(fixturesCLI, tmp, f),
-          files: [ resolvedJS ],
+          files: [ resolvedJS ]
         })
       })
     })
@@ -80,14 +82,14 @@ t.test('check out the index', t => {
   t.match(index, {
     processes: {},
     files: {
-      [resolvedJS]: [u, u, u, u, u, u, u, u, u ],
+      [resolvedJS]: [ u, u, u, u, u, u, u, u, u ]
     },
     externalIds: {
       blorp: {
         root: u,
-        children: [u, u, u, u, u, u, u, u ],
-      },
-    },
+        children: [ u, u, u, u, u, u, u, u ]
+      }
+    }
   })
   t.end()
 })


### PR DESCRIPTION
THIS IS A WIP COMMIT FOR REVIEW ONLY, DO NOT MERGE

- [ ] docs
- [x] tests

---

feat: add processinfo index, add externalId

If a NYC_PROCESSINFO_EXTERNAL_ID environment variable is set, then it is
saved in the processinfo as `externalId`.

BREAKING CHANGE: This adds a file named 'index.json' to the
.nyc_output/processinfo directory, which has a different format from the
other files in this dir.

Furthermore, when this file is generated, some additional helpful
metadata is memoized to the processinfo json files, to minimize the cost
of repeated generation.  (This isn't necessarily a breaking change, but
it is an update to the de facto schema for those files.)

As soon as possible, index generation and process tree display should be
migrated out to a new 'istanbul-lib-processinfo' library.

This opens the door to add features in the v14 release family to improve
support for partial/resumed test runs and file watching.

- When a process is run with --clean=false and a previously seen
  externalId, clear away all the coverage files in the set for that
  externalId.
- When a file is changed, a test runner can use the index to determine
  which tests (by externalId) ought to be re-run.