### PR TITLE
fix: set processinfo pid/ppid to actual numbers

### DIFF
--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -1,15 +1,13 @@
 var sw = require('spawn-wrap')
 var NYC = require('../index.js')
 
-var parentPid = process.env.NYC_PARENT_PID || '0'
-process.env.NYC_PARENT_PID = process.pid
-
 var config = {}
 if (process.env.NYC_CONFIG) config = JSON.parse(process.env.NYC_CONFIG)
 config.isChildProcess = true
 
 config._processInfo = {
-  ppid: parentPid,
+  pid: process.pid,
+  ppid: process.ppid,
   root: process.env.NYC_ROOT_ID
 }
 

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -1127,7 +1127,13 @@ describe('the nyc cli', function () {
       proc.on('close', function (code) {
         code.should.equal(0)
         stdout.should.not.match(new RegExp('└─'))
-        fs.statSync(path.resolve(fixturesCLI, '.nyc_output', 'processinfo'))
+        const dir = path.resolve(fixturesCLI, '.nyc_output', 'processinfo')
+        fs.statSync(dir)
+        // make sure that the processinfo file has a numeric pid and ppid
+        const files = fs.readdirSync(dir).filter(f => f !== 'index.json')
+        const data = JSON.parse(fs.readFileSync(dir + '/' + files[0], 'utf8'))
+        data.pid.should.be.a('number')
+        data.ppid.should.be.a('number')
         done()
       })
     })


### PR DESCRIPTION
As of Node.js v6, process.ppid is available, and a number.  So, there's
no need to pass the parent PID through the environment, which casts it
to a string.