### PR TITLE
fix: Use a single instance of nyc for all actions of main command.

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -66,34 +66,22 @@ if ([
     var mainChildExitCode = process.exitCode
 
     if (argv.checkCoverage) {
-      checkCoverage(argv)
+      nyc.checkCoverage({
+        lines: argv.lines,
+        functions: argv.functions,
+        branches: argv.branches,
+        statements: argv.statements
+      }, argv['per-file'])
       process.exitCode = process.exitCode || mainChildExitCode
-      if (!argv.silent) report(argv)
-      return done()
-    } else {
-      if (!argv.silent) report(argv)
-      return done()
     }
+
+    if (!argv.silent) {
+      nyc.report()
+    }
+
+    return done()
   })
 } else {
   // I don't have a clue what you're doing.
   yargs.showHelp()
-}
-
-function report (argv) {
-  process.env.NYC_CWD = process.cwd()
-
-  var nyc = new NYC(argv)
-  nyc.report()
-}
-
-function checkCoverage (argv, cb) {
-  process.env.NYC_CWD = process.cwd()
-
-  ;(new NYC(argv)).checkCoverage({
-    lines: argv.lines,
-    functions: argv.functions,
-    branches: argv.branches,
-    statements: argv.statements
-  }, argv['per-file'])
 }


### PR DESCRIPTION
This shares the same instance of nyc for execution, checking coverage
and reporting.