### PR TITLE
feat: always build the processinfo temp dir

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -65,9 +65,7 @@ if ([
   ), function (done) {
     var mainChildExitCode = process.exitCode
 
-    if (argv.showProcessTree || argv.buildProcessTree) {
-      nyc.writeProcessIndex()
-    }
+    nyc.writeProcessIndex()
 
     if (argv.checkCoverage) {
       nyc.checkCoverage({

--- a/index.js
+++ b/index.js
@@ -40,7 +40,6 @@ function NYC (config) {
   this._reportDir = config.reportDir || 'coverage'
   this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true
   this._showProcessTree = config.showProcessTree || false
-  this._buildProcessTree = this._showProcessTree || config.buildProcessTree
   this._eagerInstantiation = config.eager || false
   this.cwd = config.cwd || process.cwd()
   this.reporter = [].concat(config.reporter || 'text')
@@ -293,9 +292,7 @@ NYC.prototype.createTempDirectory = function () {
   mkdirp.sync(this.tempDirectory())
   if (this.cache) mkdirp.sync(this.cacheDirectory)
 
-  if (this._buildProcessTree) {
-    mkdirp.sync(this.processInfoDirectory())
-  }
+  mkdirp.sync(this.processInfoDirectory())
 }
 
 NYC.prototype.reset = function () {
@@ -350,10 +347,6 @@ NYC.prototype.writeCoverageFile = function () {
     JSON.stringify(coverage),
     'utf-8'
   )
-
-  if (!this._buildProcessTree) {
-    return
-  }
 
   this.processInfo.coverageFilename = coverageFilename
   this.processInfo.files = Object.keys(coverage)

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -229,12 +229,6 @@ Config.buildYargs = function (cwd) {
       type: 'boolean',
       global: false
     })
-    .option('build-process-tree', {
-      describe: 'create files for the tree of spawned processes',
-      default: false,
-      type: 'boolean',
-      global: false
-    })
     .option('clean', {
       describe: 'should the .nyc_output folder be cleaned before executing tests',
       default: true,

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -1090,70 +1090,6 @@ describe('the nyc cli', function () {
         done()
       })
     })
-
-    it('doesn’t create the temp directory for process info files when not present', function (done) {
-      var args = [bin, process.execPath, 'selfspawn-fibonacci.js', '5']
-
-      var proc = spawn(process.execPath, args, {
-        cwd: fixturesCLI,
-        env: env
-      })
-
-      proc.on('exit', function (code) {
-        code.should.equal(0)
-        fs.stat(path.resolve(fixturesCLI, '.nyc_output', 'processinfo'), function (err, stat) {
-          err.code.should.equal('ENOENT')
-          done()
-        })
-      })
-    })
-  })
-
-  describe('--build-process-tree', function () {
-    it('builds, but does not display, a tree of spawned processes', function (done) {
-      var args = [bin, '--build-process-tree', process.execPath, 'selfspawn-fibonacci.js', '5']
-
-      var proc = spawn(process.execPath, args, {
-        cwd: fixturesCLI,
-        env: env
-      })
-
-      var stdout = ''
-      proc.stdout.setEncoding('utf8')
-      proc.stdout.on('data', function (chunk) {
-        stdout += chunk
-      })
-
-      proc.on('close', function (code) {
-        code.should.equal(0)
-        stdout.should.not.match(new RegExp('└─'))
-        const dir = path.resolve(fixturesCLI, '.nyc_output', 'processinfo')
-        fs.statSync(dir)
-        // make sure that the processinfo file has a numeric pid and ppid
-        const files = fs.readdirSync(dir).filter(f => f !== 'index.json')
-        const data = JSON.parse(fs.readFileSync(dir + '/' + files[0], 'utf8'))
-        data.pid.should.be.a('number')
-        data.ppid.should.be.a('number')
-        done()
-      })
-    })
-
-    it('doesn’t create the temp directory for process info files when not present', function (done) {
-      var args = [bin, process.execPath, 'selfspawn-fibonacci.js', '5']
-
-      var proc = spawn(process.execPath, args, {
-        cwd: fixturesCLI,
-        env: env
-      })
-
-      proc.on('exit', function (code) {
-        code.should.equal(0)
-        fs.stat(path.resolve(fixturesCLI, '.nyc_output', 'processinfo'), function (err, stat) {
-          err.code.should.equal('ENOENT')
-          done()
-        })
-      })
-    })
   })
 
   describe('--temp-dir', function () {
@@ -1174,7 +1110,7 @@ describe('the nyc cli', function () {
       proc.on('close', function (code) {
         code.should.equal(0)
         var tempFiles = fs.readdirSync(path.resolve(fixturesCLI, '.nyc_output'))
-        tempFiles.length.should.equal(1)
+        tempFiles.length.should.equal(2) // the coverage file, and processinfo
         var cliFiles = fs.readdirSync(path.resolve(fixturesCLI))
         cliFiles.should.include('.nyc_output')
         cliFiles.should.not.include('.temp_dir')
@@ -1194,7 +1130,7 @@ describe('the nyc cli', function () {
       proc.on('exit', function (code) {
         code.should.equal(0)
         var tempFiles = fs.readdirSync(path.resolve(fixturesCLI, '.temp_directory'))
-        tempFiles.length.should.equal(1)
+        tempFiles.length.should.equal(2)
         var cliFiles = fs.readdirSync(path.resolve(fixturesCLI))
         cliFiles.should.not.include('.nyc_output')
         cliFiles.should.not.include('.temp_dir')
@@ -1214,7 +1150,7 @@ describe('the nyc cli', function () {
       proc.on('exit', function (code) {
         code.should.equal(0)
         var tempFiles = fs.readdirSync(path.resolve(fixturesCLI, '.temp_dir'))
-        tempFiles.length.should.equal(1)
+        tempFiles.length.should.equal(2)
         var cliFiles = fs.readdirSync(path.resolve(fixturesCLI))
         cliFiles.should.not.include('.nyc_output')
         cliFiles.should.include('.temp_dir')

--- a/test/processinfo.js
+++ b/test/processinfo.js
@@ -14,7 +14,7 @@ t.teardown(() => rimraf.sync(resolve(fixturesCLI, tmp)))
 
 t.test('build some processinfo', t => {
   var args = [
-    bin, '-t', tmp, '--build-process-tree',
+    bin, '-t', tmp,
     node, 'selfspawn-fibonacci.js', '5'
   ]
   var proc = spawn(process.execPath, args, {


### PR DESCRIPTION
Always build the processinfo data directory (with index) in
${tmpdir}/processinfo.  This more easily supports cases where the
processinfo index may be useful for later analysis, or generating the
process tree post hoc.

BREAKING CHANGE: this removes the --build-process-tree option, which
appeared in previous 14.0.0 prerelease versions.