### PR TITLE
docs: instrument docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,22 +197,45 @@ nyc report --reporter=<custom-reporter-name>
 
 ## Producing instrumented source
 
-The `nyc instrument` command can produce a set of instrumented source files.
-These files are suitable for client side deployment in end to end testing.
-You can create an instrumented version of your source code by running:
+The `nyc instrument` command can produce instrumented source files.
+These files are suitable for client side deployment during end to end testing.
+You can either pre-instrument your source, or instrument to a stream.
+ 
+You can create pre-instrumented source code by running:
 
 ```bash
 nyc instrument <input> [output]
 ```
 
 `<input>` can be any file or directory within the project root directory.
-The `[output]` directory is optional and can be located anywhere, if it is not set the instrumented code will be sent to `stdout`.
+The `[output]` directory is optional and can be located anywhere, if not set the instrumented code will be sent to `stdout`.
 For example, `nyc instrument . ./output` will produce instrumented versions of any source files it finds in `.` and store them in `./output`.
 
-Any existing output can be removed by specifying the `--delete` option.
+Existing output can be removed by specifying the `--delete` option.
+The `--complete-copy` option will copy all files from the `input` directory to the `output` directory.
+Note that `nyc instrument` will not copy the contents of a `.git` folder to the output directory.
 Run `nyc instrument --help` to display a full list of available command options.
 
-**Note:** `nyc instrument` will not copy the contents of a `.git` folder to the output directory.
+**Note:** `--complete-copy` will dereference any symlinks during the copy process, this may stop scripts running properly from the output directory.
+
+You can instrument source as a stream with:
+ 
+```bash
+nyc instrument <input>
+```
+
+This form of the command will stream instrumented source directly to `stdout`, that can then be piped to another process.
+You can use this behaviour to create a server that can instrument files on request.
+The following example shows streaming instrumentation middleware capable of instrumenting requested files.
+
+```javascript
+app.use((req, res, next) => {
+  const myOptions = ""
+  const filename = myHelper.getFilename(req)
+  const nyc = cp.spawn(`nyc instrument ${myOptions} ${filename}`)
+  nyc.stdout.pipe(res)
+})
+```
 
 ## Setting the project root directory
 

--- a/README.md
+++ b/README.md
@@ -195,47 +195,7 @@ Install custom reporters as a development dependency and you can use the `--repo
 nyc report --reporter=<custom-reporter-name>
 ```
 
-## Producing instrumented source
-
-The `nyc instrument` command can produce instrumented source files.
-These files are suitable for client side deployment during end to end testing.
-You can either pre-instrument your source, or instrument to a stream.
- 
-You can create pre-instrumented source code by running:
-
-```bash
-nyc instrument <input> [output]
-```
-
-`<input>` can be any file or directory within the project root directory.
-The `[output]` directory is optional and can be located anywhere, if not set the instrumented code will be sent to `stdout`.
-For example, `nyc instrument . ./output` will produce instrumented versions of any source files it finds in `.` and store them in `./output`.
-
-Existing output can be removed by specifying the `--delete` option.
-The `--complete-copy` option will copy all files from the `input` directory to the `output` directory.
-Note that `nyc instrument` will not copy the contents of a `.git` folder to the output directory.
-Run `nyc instrument --help` to display a full list of available command options.
-
-**Note:** `--complete-copy` will dereference any symlinks during the copy process, this may stop scripts running properly from the output directory.
-
-You can instrument source as a stream with:
- 
-```bash
-nyc instrument <input>
-```
-
-This form of the command will stream instrumented source directly to `stdout`, that can then be piped to another process.
-You can use this behaviour to create a server that can instrument files on request.
-The following example shows streaming instrumentation middleware capable of instrumenting requested files.
-
-```javascript
-app.use((req, res, next) => {
-  const myOptions = ""
-  const filename = myHelper.getFilename(req)
-  const nyc = cp.spawn(`nyc instrument ${myOptions} ${filename}`)
-  nyc.stdout.pipe(res)
-})
-```
+## [Producing instrumented source](./docs/instrument-command.md)
 
 ## Setting the project root directory
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Install custom reporters as a development dependency and you can use the `--repo
 nyc report --reporter=<custom-reporter-name>
 ```
 
-## [Producing instrumented source](./docs/instrument-command.md)
+## [Producing instrumented source](./docs/instrument.md)
 
 ## Setting the project root directory
 

--- a/docs/instrument.md
+++ b/docs/instrument.md
@@ -1,0 +1,49 @@
+
+## Producing instrumented source
+
+The `nyc instrument` command can produce instrumented source files.
+These files are suitable for client side deployment during end to end testing.
+You can either pre-instrument your source, or write instrumented source to a stream.
+
+Run `nyc instrument --help` to display a full list of available command options.
+ 
+### Pre-instrumented source 
+ 
+You can create pre-instrumented source code by running:
+
+```bash
+nyc instrument <input> [output]
+```
+
+`<input>` can be any file or directory within the project root directory.
+The `[output]` directory is optional and can be located anywhere, if not set the instrumented code will be sent to `stdout`.
+For example, `nyc instrument . ./output` will produce instrumented versions of any source files it finds in `.` and store them in `./output`.
+
+The `--delete` option will remove existing output.
+
+The `--complete-copy` option will copy all files from the `input` directory to the `output` directory.
+When using `--complete-copy` nyc will not copy the contents of a `.git` folder to the output directory.
+
+
+**Note:** `--complete-copy` will dereference any symlinks during the copy process, this may stop scripts running properly from the output directory.
+
+### Instrument source on request
+
+You can provide instrumented source as a stream with:
+ 
+```bash
+nyc instrument <input>
+```
+
+This form of the command will stream instrumented source directly to `stdout`, that can then be piped to another process.
+You can use this behaviour to create a server that can instrument files on request.
+The following example shows streaming instrumentation middleware capable of instrumenting files on request.
+
+```javascript
+app.use((req, res, next) => {
+  const myOptions = ""
+  const filename = myHelper.getFilename(req)
+  const nyc = cp.spawn(`nyc instrument ${myOptions} ${filename}`)
+  nyc.stdout.pipe(res)
+})
+```

--- a/docs/instrument.md
+++ b/docs/instrument.md
@@ -1,5 +1,4 @@
-
-## Producing instrumented source
+# Producing instrumented source
 
 The `nyc instrument` command can produce instrumented source files.
 These files are suitable for client side deployment during end to end testing.
@@ -7,7 +6,7 @@ You can either pre-instrument your source, or write instrumented source to a str
 
 Run `nyc instrument --help` to display a full list of available command options.
  
-### Pre-instrumented source 
+## Pre-instrumented source 
  
 You can create pre-instrumented source code by running:
 
@@ -19,21 +18,14 @@ nyc instrument <input> [output]
 The `[output]` directory is optional and can be located anywhere, if not set the instrumented code will be sent to `stdout`.
 For example, `nyc instrument . ./output` will produce instrumented versions of any source files it finds in `.` and store them in `./output`.
 
-The `--delete` option will remove existing output.
+The `--delete` option will remove the existing output directory before instrumenting.
 
-The `--complete-copy` option will copy all files from the `input` directory to the `output` directory.
+The `--complete-copy` option will copy all remaining files from the `input` directory to the `output` directory.
 When using `--complete-copy` nyc will not copy the contents of a `.git` folder to the output directory.
-
 
 **Note:** `--complete-copy` will dereference any symlinks during the copy process, this may stop scripts running properly from the output directory.
 
-### Instrument source on request
-
-You can provide instrumented source as a stream with:
- 
-```bash
-nyc instrument <input>
-```
+## Streaming instrumentation
 
 This form of the command will stream instrumented source directly to `stdout`, that can then be piped to another process.
 You can use this behaviour to create a server that can instrument files on request.

--- a/docs/instrument.md
+++ b/docs/instrument.md
@@ -27,7 +27,7 @@ When using `--complete-copy` nyc will not copy the contents of a `.git` folder t
 
 ## Streaming instrumentation
 
-This form of the command will stream instrumented source directly to `stdout`, that can then be piped to another process.
+`nyc instrument` will stream instrumented source directly to `stdout`, that can then be piped to another process.
 You can use this behaviour to create a server that can instrument files on request.
 The following example shows streaming instrumentation middleware capable of instrumenting files on request.
 


### PR DESCRIPTION
Add documentation for `--complete-copy`, and describe how to instrument source JIT on an express server.

This should go some way to addressing #839, which looks like it's already implemented but not documented.