### PR TITLE
fix: Exit with code 1 when nyc doesn't know what to do.

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -85,5 +85,6 @@ if ([
   })
 } else {
   // I don't have a clue what you're doing.
+  process.exitCode = 1
   yargs.showHelp()
 }

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -12,7 +12,7 @@ const glob = require('glob')
 const isWindows = require('is-windows')()
 const rimraf = require('rimraf')
 const makeDir = require('make-dir')
-const spawn = require('child_process').spawn
+const { spawn, spawnSync } = require('child_process')
 const si = require('strip-indent')
 
 require('chai').should()
@@ -1077,6 +1077,23 @@ describe('the nyc cli', function () {
         done()
       })
     })
+  })
+
+  it('help shows to stderr when main command doesn\'t know what to do', () => {
+    const opts = {
+      cwd: fixturesCLI,
+      env,
+      encoding: 'utf8'
+    }
+
+    const help = spawnSync(process.execPath, [bin, '--help'], opts)
+    const unknown = spawnSync(process.execPath, [bin], opts)
+    help.status.should.equal(0)
+    unknown.status.should.equal(1)
+    help.stderr.should.equal('')
+    unknown.stdout.should.equal('')
+    help.stdout.should.not.equal('')
+    help.stdout.should.equal(unknown.stderr)
   })
 
   describe('args', function () {


### PR DESCRIPTION
When nyc is not told to do anything this is an error.  We already
printed the help message to stderr, now we exit with code 1 to indicate
that nyc exited without doing anything.

Add a test to cover this edge case and verify that both `nyc` and `nyc
--help` produce output as expected to stdout and stderr, exit with the
proper code.