### PR TITLE
chore: Add test for `nyc --no-clean`.

### DIFF
--- a/test/fixtures/cli/by-arg2.js
+++ b/test/fixtures/cli/by-arg2.js
@@ -1,0 +1,8 @@
+const arg = process.argv[2];
+if (arg === '1') {
+  console.log('1')
+} else if (arg === '2') {
+  console.log('2')
+} else {
+  console.log('unexpected')
+}

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -12,7 +12,7 @@ const glob = require('glob')
 const isWindows = require('is-windows')()
 const rimraf = require('rimraf')
 const makeDir = require('make-dir')
-const spawn = require('child_process').spawn
+const { spawn, spawnSync } = require('child_process')
 const si = require('strip-indent')
 
 require('chai').should()
@@ -1235,6 +1235,48 @@ describe('the nyc cli', function () {
         done()
       })
     })
+  })
+
+  it('handles --clean / --no-clean properly', () => {
+    rimraf.sync(path.resolve(fixturesCLI, '.nyc_output'))
+    const args = (doClean, arg) => [
+      bin,
+      doClean ? '--clean' : '--no-clean',
+      process.execPath,
+      './by-arg2.js',
+      arg
+    ]
+    const opts = {
+      cwd: fixturesCLI,
+      env: env,
+      encoding: 'utf8'
+    }
+
+    const proc1 = spawnSync(process.execPath, args(true, '1'), opts)
+    proc1.status.should.equal(0)
+    stdoutShouldEqual(proc1.stdout, `
+      1
+      ------------|----------|----------|----------|----------|-------------------|
+      File        |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+      ------------|----------|----------|----------|----------|-------------------|
+      All files   |       50 |       25 |      100 |       50 |                   |
+       by-arg2.js |       50 |       25 |      100 |       50 |             4,5,7 |
+      ------------|----------|----------|----------|----------|-------------------|`
+    )
+    proc1.stderr.should.equal('')
+
+    const proc2 = spawnSync(process.execPath, args(false, '2'), opts)
+    proc2.status.should.equal(0)
+    stdoutShouldEqual(proc2.stdout, `
+      2
+      ------------|----------|----------|----------|----------|-------------------|
+      File        |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+      ------------|----------|----------|----------|----------|-------------------|
+      All files   |    83.33 |       75 |      100 |    83.33 |                   |
+       by-arg2.js |    83.33 |       75 |      100 |    83.33 |                 7 |
+      ------------|----------|----------|----------|----------|-------------------|`
+    )
+    proc2.stderr.should.equal('')
   })
 
   describe('noop instrumenter', function () {


### PR DESCRIPTION
Verify that running `nyc command1 && nyc --no-clean command2` causes
results results to be merged.