### PR TITLE
chore: remove vestigial environment variables

### DIFF
--- a/bin/nyc.js
+++ b/bin/nyc.js
@@ -41,9 +41,7 @@ if ([
     // https://github.com/istanbuljs/nyc/issues/951
     SPAWN_WRAP_SHIM_ROOT: process.env.SPAWN_WRAP_SHIM_ROOT || process.env.XDG_CACHE_HOME || require('os').homedir(),
     NYC_CONFIG: JSON.stringify(argv),
-    NYC_CWD: process.cwd(),
-    NYC_ROOT_ID: nyc.rootId,
-    NYC_INSTRUMENTER: argv.instrumenter
+    NYC_CWD: process.cwd()
   }
 
   if (argv['babel-cache'] === false) {

--- a/bin/wrap.js
+++ b/bin/wrap.js
@@ -8,8 +8,7 @@ config.isChildProcess = true
 config._processInfo = {
   pid: process.pid,
   ppid: process.ppid,
-  parent: process.env.NYC_PROCESS_ID || null,
-  root: process.env.NYC_ROOT_ID
+  parent: process.env.NYC_PROCESS_ID || null
 }
 if (process.env.NYC_PROCESSINFO_EXTERNAL_ID) {
   config._processInfo.externalId = process.env.NYC_PROCESSINFO_EXTERNAL_ID

--- a/index.js
+++ b/index.js
@@ -21,7 +21,6 @@ const rimraf = require('rimraf')
 const SourceMaps = require('./lib/source-maps')
 const testExclude = require('test-exclude')
 const util = require('util')
-const uuid = require('uuid/v4')
 
 const debugLog = util.debuglog('nyc')
 
@@ -89,7 +88,6 @@ class NYC {
     this.fakeRequire = null
 
     this.processInfo = new ProcessInfo(config && config._processInfo)
-    this.rootId = this.processInfo.root || uuid()
 
     this.hashCache = {}
   }

--- a/lib/process.js
+++ b/lib/process.js
@@ -13,7 +13,6 @@ function ProcessInfo (defaults) {
   this.cwd = process.cwd()
   this.time = Date.now()
   this.ppid = null
-  this.root = null
   this.coverageFilename = null
 
   for (var key in defaults) {

--- a/test/processinfo.js
+++ b/test/processinfo.js
@@ -65,7 +65,6 @@ t.test('validate the created processinfo data', t => {
           execArgv: [],
           cwd: fixturesCLI,
           time: Number,
-          root: /^[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}$/,
           coverageFilename: resolve(fixturesCLI, tmp, f),
           files: [ resolvedJS ]
         })
@@ -86,7 +85,6 @@ t.test('check out the index', t => {
     },
     externalIds: {
       blorp: {
-        root: u,
         children: [ u, u, u, u, u, u, u, u ]
       }
     }


### PR DESCRIPTION
This removes the NYC_ROOT_ID and NYC_INSTRUMENTER environment variables, which are no longer used or necessary.

Probably best to leave NYC_CWD in place, since it's more load-bearing, and is sometimes inspected in user code to determine whether or not they're being covered by NYC.