### PR TITLE
chore: node.js 12 compatibility for object snapshot test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "standard",
     "pretest": "npm run lint && npm run clean && npm run instrument",
     "test": "tap -t360 --no-cov -b test/*.js",
-    "snap": "cross-env TAP_SNAPSHOT=1 tap -t360 --no-cov -b test/*.js",
+    "snap": "cross-env TAP_SNAPSHOT=1 npm test",
     "posttest": "npm run report",
     "clean": "rimraf ./.nyc_output ./node_modules/.cache ./.self_coverage ./test/fixtures/.nyc_output ./test/fixtures/node_modules/.cache ./self-coverage",
     "instrument": "node ./build-self-coverage.js",

--- a/tap-snapshots/test-nyc-integration.js-TAP.test.js
+++ b/tap-snapshots/test-nyc-integration.js-TAP.test.js
@@ -190,15 +190,44 @@ All files        |       50 |       50 |      100 |       50 |                  
 `
 
 exports[`test/nyc-integration.js TAP passes configuration via environment variables > undefined 1`] = `
-{ silent: true,
-  cache: false,
-  sourceMap: true,
-  require: 'make-dir',
-  include: 'env.js',
-  exclude: 'batman.js',
-  extension: '.js',
-  cacheDir: '/tmp',
-  instrumenter: './lib/instrumenters/istanbul' }
+[
+  [
+    "cache",
+    false
+  ],
+  [
+    "cacheDir",
+    "/tmp"
+  ],
+  [
+    "exclude",
+    "batman.js"
+  ],
+  [
+    "extension",
+    ".js"
+  ],
+  [
+    "include",
+    "env.js"
+  ],
+  [
+    "instrumenter",
+    "./lib/instrumenters/istanbul"
+  ],
+  [
+    "require",
+    "make-dir"
+  ],
+  [
+    "silent",
+    true
+  ],
+  [
+    "sourceMap",
+    true
+  ]
+]
 `
 
 exports[`test/nyc-integration.js TAP allows package.json configuration to be overridden with command line args > stdout 1`] = `

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 const os = require('os')
-const util = require('util')
 
 const t = require('tap')
 

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const os = require('os')
+const util = require('util')
 
 const t = require('tap')
 
@@ -97,14 +98,17 @@ t.test('passes configuration via environment variables', t => {
       'extension'
     ]
 
-    const { NYC_CONFIG } = JSON.parse(stdout)
-    const config = JSON.parse(NYC_CONFIG, (key, value) => {
-      return key === '' || checkOptions.includes(key) ? value : undefined
-    })
+    const config = JSON.parse(JSON.parse(stdout).NYC_CONFIG)
 
     t.is(status, 0)
     t.is(stderr, '')
-    t.matchSnapshot(config)
+    t.matchSnapshot(
+      JSON.stringify(
+        checkOptions.sort().map(option => [option, config[option]]),
+        null,
+        2
+      )
+    )
   })
 })
 


### PR DESCRIPTION
node.js 12 changes the format of `util.inspect`, this causes snapshot
mismatch.  We only use object snapshot testing in one place so call
`util.inspect` manually with `compact: false` option to force consistent
output before / after node.js 12.

---

CC @isaacs not sure if tap@12 can/should do anything about this, kind of a tough situation as `compact: false` would be a breaking change for tap.  Either way figure you might want to know about this.