### PR TITLE
Readme Reshuffle

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -20,7 +20,6 @@ create a basic `nyc-bug-demo` repository and link to that please [mandatory].
 <!--
 [mandatory] run the following script: 
   npx envinfo@latest --preset nyc
-  npx nyc --version
 -->
 ```
 # paste the output here

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,7 +18,9 @@ create a basic `nyc-bug-demo` repository and link to that please [mandatory].
 
 ## Environment Information
 <!--
-[mandatory] run the following script: npx envinfo@latest --preset nyc
+[mandatory] run the following script: 
+  npx envinfo@latest --preset nyc
+  npx nyc --version
 -->
 ```
 # paste the output here

--- a/README.md
+++ b/README.md
@@ -78,15 +78,15 @@ This table is a quick TLDR for the rest of this readme and there are more advanc
 
 | Option name | Description | Type | Default |
 | ----------- | ----------- | ---- | ------- |
-| `all` | whether or not to instrument all files (not just the ones touched by your test suite) | `Boolean` | `false` |
-| `check-coverage` | check whether coverage is within thresholds, fail if not | `Boolean` | `false` |
-| `extension` | a list of extensions that nyc should attempt to handle in addition to `.js` | `Array<String>` | `['.js']` |
-| `include` | [globs of files to be included from instrumentation](#selecting-files-for-coverage) | `Array<String>` | `['**']`|
-| `exclude` | See [selecting files for coverage for more info](#selecting-files-for-coverage) | `Array<String>` | [list](https://github.com/istanbuljs/istanbuljs/blob/master/packages/test-exclude/index.js#L176-L184) |
-| `reporter` | [coverage reporters to use](https://istanbul.js.org/docs/advanced/alternative-reporters/) | `Array<String>` | `['text']` |
-| `report-dir` | where to put the coverage report files | `String` | `./coverage` |
-| `skip-full` | don't show files with 100% statement, branch, and function coverage | `Boolean` | `false` |
-| `temp-dir` | directory to output raw coverage information to | `String` | `./.nyc_output` |
+| `all` | Whether or not to instrument all files (not just the ones touched by your test suite) | `Boolean` | `false` |
+| `check-coverage` | Check whether coverage is within thresholds, fail if not | `Boolean` | `false` |
+| `extension` | List of extensions that nyc should attempt to handle in addition to `.js` | `Array<String>` | `['.js']` |
+| `include` | See [selecting files for coverage] for more info | `Array<String>` | `['**']`|
+| `exclude` | See [selecting files for coverage] for more info | `Array<String>` | [list](https://github.com/istanbuljs/istanbuljs/blob/master/packages/test-exclude/index.js#L176-L184) |
+| `reporter` | [Coverage reporters to use](https://istanbul.js.org/docs/advanced/alternative-reporters/) | `Array<String>` | `['text']` |
+| `report-dir` | Where to put the coverage report files | `String` | `./coverage` |
+| `skip-full` | Don't show files with 100% statement, branch, and function coverage | `Boolean` | `false` |
+| `temp-dir` | Directory to output raw coverage information to | `String` | `./.nyc_output` |
 
 Configuration can also be provided by `nyc.config.js` if programmed logic is required:
 ```js
@@ -117,7 +117,7 @@ As an example, an alternative way to configure nyc for `babel-plugin-istanbul` w
 }
 ```
 
-To publish and reuse your own `nyc` configuration, simply create an npm module that exports an `index.json` with your `nyc` config.
+To publish and reuse your own `nyc` configuration, simply create an npm module that exports your JSON config (via [`index.json`](https://github.com/istanbuljs/istanbuljs/blob/master/packages/nyc-config-typescript/) or a CJS [`index.js`](https://github.com/istanbuljs/istanbuljs/blob/master/packages/nyc-config-hook-run-in-this-context/)).
 
 ## Selecting files for coverage
 
@@ -354,3 +354,4 @@ Take a look at http://istanbul.js.org/docs/advanced/ and please feel free to [co
 
 [`@babel/register`]: https://www.npmjs.com/package/@babel/register
 [`babel-plugin-istanbul`]: https://github.com/istanbuljs/babel-plugin-istanbul
+[selecting files for coverage]: #selecting-files-for-coverage

--- a/README.md
+++ b/README.md
@@ -13,46 +13,31 @@ Istanbul's state of the art command line interface, with support for:
 * applications that spawn subprocesses.
 * ES2015 transforms, via [`babel-plugin-istanbul`], or source-maps.
 
-## Instrumenting your code
+## Installation & Usage
 
-You can install nyc as a development dependency and add it to the test stanza
-in your package.json.
-
-```shell
-npm i nyc --save-dev
-```
+You can use `npx` instead of installing nyc as a dependency.
+Simply add `nyc` before your test runner is invoked (replace `mocha` with your test runner everywhere you see it):
 
 ```json
 {
   "scripts": {
-    "test": "nyc mocha"
+    "test": "npx nyc mocha"
   }
 }
 ```
 
-Alternatively, you can install nyc globally and use it to execute `npm test`:
-
-```shell
-npm i nyc -g
-```
-
-```shell
-nyc npm test
-```
-
-nyc accepts a wide variety of configuration arguments, run `nyc --help` for
-thorough documentation.
-
-Configuration arguments should be provided prior to the program that nyc
-is executing. As an example, the following command executes `npm test`,
-and indicates to nyc that it should output both an `lcov`
-and a `text-lcov` coverage report.
-
-```shell
-nyc --reporter=lcov --reporter=text-lcov npm test
-```
+Or use your package manager to add a dev dependency: `npm i -D nyc` or `yarn add -D nyc`.
 
 ## Configuring `nyc`
+
+nyc accepts a wide variety of configuration arguments, run `npx nyc --help` for thorough documentation.
+
+Configuration arguments on the command-line should be provided prior to the program that nyc is executing.
+As an example, the following command executes `npm test`, and indicates to nyc that it should output both an `lcov` and a `text-summary` coverage report.
+
+```shell
+npx nyc --reporter=lcov --reporter=text-summary npm test
+```
 
 ### Babel projects
 

--- a/README.md
+++ b/README.md
@@ -235,14 +235,17 @@ nyc may create artefact directories within the project root, such as:
 
 ## Require additional modules
 
-The `--require` flag can be provided to `nyc` to indicate that additional
-modules should be required in the subprocess collecting coverage:
+The `--require` flag can be provided to `nyc` to indicate that additional modules should be required in the subprocess collecting coverage:
 
-`nyc --require @babel/register --require @babel/polyfill mocha`
+```
+nyc --require @babel/register --require @babel/polyfill mocha
+```
 
 ## Caching
 
-`nyc`'s default behavior is to cache instrumented files to disk to prevent instrumenting source files multiple times, and speed `nyc` execution times. You can disable this behavior by running `nyc` with the `--cache false` flag. You can also change the default cache directory from `./node_modules/.cache/nyc` by setting the `--cache-dir` flag.
+`nyc`'s default behavior is to cache instrumented files to disk to prevent instrumenting source files multiple times, and speed `nyc` execution times.
+You can disable this behavior by running `nyc` with the `--cache false` flag.
+You can also change the default cache directory from `./node_modules/.cache/nyc` by setting the `--cache-dir` flag.
 
 ## Coverage thresholds
 
@@ -264,13 +267,10 @@ To do this check on a per-file basis (as opposed to in aggregate), set the `per-
 
 ### High and low watermarks
 
-Several of the coverage reporters supported by nyc display special information
-for high and low watermarks:
+Several of the coverage reporters supported by nyc display special information for high and low watermarks:
 
-* high-watermarks represent healthy test coverage (in many reports
-  this is represented with green highlighting).
-* low-watermarks represent sub-optimal coverage levels (in many reports
-  this is represented with red highlighting).
+* high-watermarks represent healthy test coverage (in many reports this is represented with green highlighting).
+* low-watermarks represent sub-optimal coverage levels (in many reports this is represented with red highlighting).
 
 You can specify custom high and low watermarks in nyc's configuration:
 
@@ -313,14 +313,7 @@ rather than having to ignore every instance of that method:
 }
 ```
 
-## Accurate stack traces using source-maps
-
-When `produce-source-map` is set to true, then the instrumented source files will
-include inline source maps for the instrumenter transform. When combined with
-[source-map-support](https://github.com/evanw/node-source-map-support),
-stack traces for instrumented code will reflect their original lines.
-
-### Support for custom require hooks (babel, typescript, etc.)
+## Support for custom require hooks (babel, typescript, etc.)
 
 nyc supports custom require hooks like [`@babel/register`]. nyc can load
 the hooks for you, [using the `--require` flag](#require-additional-modules).
@@ -330,7 +323,7 @@ of the pre-transpiled code. You'll have to configure your custom require hook
 to inline the source-map in the transpiled code. For Babel that means setting
 the `sourceMaps` option to `inline`.
 
-### Source-Map support for pre-instrumented codebases
+## Source-Map support for pre-instrumented codebases
 
 If you opt to pre-instrument your source-code (rather than using a just-in-time
 transpiler like [`@babel/register`]) nyc supports both inline source-maps and

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ module.exports = {
 
 To publish and reuse your own `nyc` configuration, simply create an npm module that exports your JSON config (via [`index.json`](https://github.com/istanbuljs/istanbuljs/blob/master/packages/nyc-config-typescript/) or a CJS [`index.js`](https://github.com/istanbuljs/istanbuljs/blob/master/packages/nyc-config-hook-run-in-this-context/)).
 
-A more advanced use case would be to combine multiple shared in a `nyc.config.js` file:
+A more advanced use case would be to combine multiple shared configs in a `nyc.config.js` file:
 ```js
 const babelConfig = require('@istanbuljs/nyc-config-babel');
 const hookRunInThisContextConfig = require('@istanbuljs/nyc-config-hook-run-in-this-context');
@@ -256,7 +256,7 @@ nyc may create artefact directories within the project root, such as:
 The `--require` flag can be provided to `nyc` to indicate that additional modules should be required in the subprocess collecting coverage:
 
 ```
-nyc --require @babel/register --require @babel/polyfill mocha
+nyc --require esm mocha
 ```
 
 ## Caching

--- a/README.md
+++ b/README.md
@@ -215,34 +215,6 @@ The exclude rules then prevent nyc instrumenting anything in a `test` folder and
 }
 ```
 
-## Accurate stack traces using source-maps
-
-When `produce-source-map` is set to true, then the instrumented source files will
-include inline source maps for the instrumenter transform. When combined with
-[source-map-support](https://github.com/evanw/node-source-map-support),
-stack traces for instrumented code will reflect their original lines.
-
-### Support for custom require hooks (babel, typescript, etc.)
-
-nyc supports custom require hooks like [`@babel/register`]. nyc can load
-the hooks for you, [using the `--require` flag](#require-additional-modules).
-
-Source maps are used to map coverage information back to the appropriate lines
-of the pre-transpiled code. You'll have to configure your custom require hook
-to inline the source-map in the transpiled code. For Babel that means setting
-the `sourceMaps` option to `inline`.
-
-### Source-Map support for pre-instrumented codebases
-
-If you opt to pre-instrument your source-code (rather than using a just-in-time
-transpiler like [`@babel/register`]) nyc supports both inline source-maps and
-`.map` files.
-
-_Important: If you are using nyc with a project that pre-instruments its code,
-run nyc with the configuration option `--exclude-after-remap` set to `false`.
-Otherwise nyc's reports will exclude any files that source-maps remap to folders
-covered under exclude rules._
-
 ## Setting the project root directory
 
 nyc runs a lot of file system operations relative to the project root directory.
@@ -340,6 +312,34 @@ rather than having to ignore every instance of that method:
   }
 }
 ```
+
+## Accurate stack traces using source-maps
+
+When `produce-source-map` is set to true, then the instrumented source files will
+include inline source maps for the instrumenter transform. When combined with
+[source-map-support](https://github.com/evanw/node-source-map-support),
+stack traces for instrumented code will reflect their original lines.
+
+### Support for custom require hooks (babel, typescript, etc.)
+
+nyc supports custom require hooks like [`@babel/register`]. nyc can load
+the hooks for you, [using the `--require` flag](#require-additional-modules).
+
+Source maps are used to map coverage information back to the appropriate lines
+of the pre-transpiled code. You'll have to configure your custom require hook
+to inline the source-map in the transpiled code. For Babel that means setting
+the `sourceMaps` option to `inline`.
+
+### Source-Map support for pre-instrumented codebases
+
+If you opt to pre-instrument your source-code (rather than using a just-in-time
+transpiler like [`@babel/register`]) nyc supports both inline source-maps and
+`.map` files.
+
+_Important: If you are using nyc with a project that pre-instruments its code,
+run nyc with the configuration option `--exclude-after-remap` set to `false`.
+Otherwise nyc's reports will exclude any files that source-maps remap to folders
+covered under exclude rules._
 
 ## [Integrating with coveralls](./docs/setup-coveralls.md)
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ You can use nyc to call npm scripts (assuming they don't already have nyc execut
 ```
 
 You can use also `npx` instead of installing nyc as a dependency, but you might get updates you are not ready for; to get around this, pin to a specific major version by specifying, e.g. `nyc@14`.
-In general, simply add `nyc` before your test runner is invoked:
 
 ```json
 {
@@ -48,10 +47,10 @@ Follow their documentation to enable and configure coverage reporting.
 nyc accepts a wide variety of configuration arguments, run `npx nyc --help` for thorough documentation.
 
 Configuration arguments on the command-line should be provided prior to the program that nyc is executing.
-As an example, the following command executes `npm test`, and indicates to nyc that it should output both an `lcov` and a `text-summary` coverage report.
+As an example, the following command executes `ava`, and indicates to nyc that it should output both an `lcov` (`lcov.info` + html report) and a `text-summary` coverage report.
 
 ```shell
-nyc --reporter=lcov --reporter=text-summary npm test
+nyc --reporter=lcov --reporter=text-summary ava
 ```
 
 ### Babel projects

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nyc
 
 [![Build Status](https://travis-ci.org/istanbuljs/nyc.svg?branch=master)](https://travis-ci.org/istanbuljs/nyc)
-[![Coverage Status](https://coveralls.io/repos/bcoe/nyc/badge.svg?branch=)](https://coveralls.io/r/bcoe/nyc?branch=master)
+[![Coverage Status](https://coveralls.io/repos/istanbuljs/nyc/badge.svg?branch=)](https://coveralls.io/r/istanbuljs/nyc?branch=master)
 [![NPM version](https://img.shields.io/npm/v/nyc.svg)](https://www.npmjs.com/package/nyc)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![community slack](http://devtoolscommunity.herokuapp.com/badge.svg)](http://devtoolscommunity.herokuapp.com)
@@ -11,12 +11,23 @@ _Having problems? want to contribute? join our [community slack](http://devtools
 Istanbul's state of the art command line interface, with support for:
 
 * applications that spawn subprocesses.
-* ES2015 transforms, via [`babel-plugin-istanbul`], or source-maps.
+* source mapped coverage of Babel and TypeScript projects
 
 ## Installation & Usage
 
-You can use `npx` instead of installing nyc as a dependency.
-Simply add `nyc@latest` before your test runner is invoked (replace `mocha` with your test runner everywhere you see it):
+Use your package manager to add it as a dev dependency: `npm i -D nyc` or `yarn add -D nyc`.
+You can use nyc to call npm scripts (assuming they don't already have nyc executed in them), like so (replace `mocha` with your test runner everywhere you see it):
+```json
+{
+  "scripts": {
+    "test": "mocha",
+    "coverage": "nyc npm run test"
+  }
+}
+```
+
+You can use also `npx` instead of installing nyc as a dependency, but you might get updates you are not ready for; to get around this, pin to a specific major version by specifying, e.g. `nyc@14`.
+In general, simply add `nyc` before your test runner is invoked:
 
 ```json
 {
@@ -26,16 +37,7 @@ Simply add `nyc@latest` before your test runner is invoked (replace `mocha` with
 }
 ```
 
-Or use your package manager to add it as a dev dependency: `npm i -D nyc` or `yarn add -D nyc`.
-You can also use nyc to call npm scripts (assuming they don't already have nyc executed in them), like so:
-```json
-{
-  "scripts": {
-    "test": "mocha",
-    "coverage": "nyc npm run test"
-  }
-}
-```
+This is a good way of testing upcoming releases of nyc, usually on the `next` tag.
 
 **Note**: If you use [`jest`](https://npm.im/jest) or [`tap`](https://www.node-tap.org/), you do not need to install `nyc`.
 Those runners already have the IstanbulJS libraries to provide coverage for you.
@@ -49,7 +51,7 @@ Configuration arguments on the command-line should be provided prior to the prog
 As an example, the following command executes `npm test`, and indicates to nyc that it should output both an `lcov` and a `text-summary` coverage report.
 
 ```shell
-npx nyc --reporter=lcov --reporter=text-summary npm test
+nyc --reporter=lcov --reporter=text-summary npm test
 ```
 
 ### Babel projects
@@ -89,7 +91,7 @@ Any configuration options that can be set via the command line can also be speci
 
 ### Common Configuration Options
 
-See `npx nyc --help` for all options available.
+See `nyc --help` for all options available.
 You can set these in any of the files listed above, or from the command line.
 This table is a quick TLDR for the rest of this readme and there are more advanced docs available.
 
@@ -262,7 +264,7 @@ nyc --require esm mocha
 ### Interaction with `--all` flag
 
 The `--require` flag also operates on the main nyc process for use by `--all`.
-For example, in situations with `nyc --all --instrument false` and babel-plugin-istanbul setup the `--all` option only works if `--require @babel/register` is passed to nyc.
+For example, in situations with `nyc --all --instrument false` and [`babel-plugin-istanbul`] setup the `--all` option only works if `--require @babel/register` is passed to nyc.
 Passing it to mocha would cause the tests to be instrumented but unloaded sources would not be seen.
 The [`@istanbuljs/nyc-config-babel`] package handles this for you!
 

--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ npx nyc --reporter=lcov --reporter=text-summary npm test
 
 ### Babel projects
 
-Please start with the pre-configured [@istanbuljs/nyc-config-babel preset](https://www.npmjs.com/package/@istanbuljs/nyc-config-babel).
+Please start with the pre-configured [`@istanbuljs/nyc-config-babel`] preset.
 You can add your custom configuration options as shown below.
 
 ### TypeScript projects
 
-Please start with the pre-configured [@istanbuljs/nyc-config-typescript preset](https://www.npmjs.com/package/@istanbuljs/nyc-config-typescript).
+Please start with the pre-configured [`@istanbuljs/nyc-config-typescript`](https://www.npmjs.com/package/@istanbuljs/nyc-config-typescript) preset.
 
 #### Adding your overrides
 
-nyc allows you to inherit other configurations using the key `extends`.
+nyc allows you to inherit other configurations using the key `extends` in the `package.json` stanza, `.nycrc`, or YAML files.
 You can then add the specific configuration options you want that aren't in that particular shared config, e.g.
 ```json
 {
@@ -259,6 +259,13 @@ The `--require` flag can be provided to `nyc` to indicate that additional module
 nyc --require esm mocha
 ```
 
+### Interaction with `--all` flag
+
+The `--require` flag also operates on the main nyc process for use by `--all`.
+For example, in situations with `nyc --all --instrument false` and babel-plugin-istanbul setup the `--all` option only works if `--require @babel/register` is passed to nyc.
+Passing it to mocha would cause the tests to be instrumented but unloaded sources would not be seen.
+The [`@istanbuljs/nyc-config-babel`] package handles this for you!
+
 ## Caching
 
 `nyc`'s default behavior is to cache instrumented files to disk to prevent instrumenting source files multiple times, and speed `nyc` execution times.
@@ -372,4 +379,5 @@ Take a look at http://istanbul.js.org/docs/advanced/ and please feel free to [co
 
 [`@babel/register`]: https://www.npmjs.com/package/@babel/register
 [`babel-plugin-istanbul`]: https://github.com/istanbuljs/babel-plugin-istanbul
+[`@istanbuljs/nyc-config-babel`]: https://www.npmjs.com/package/@istanbuljs/nyc-config-babel
 [selecting files for coverage]: #selecting-files-for-coverage

--- a/README.md
+++ b/README.md
@@ -16,17 +16,30 @@ Istanbul's state of the art command line interface, with support for:
 ## Installation & Usage
 
 You can use `npx` instead of installing nyc as a dependency.
-Simply add `nyc` before your test runner is invoked (replace `mocha` with your test runner everywhere you see it):
+Simply add `nyc@latest` before your test runner is invoked (replace `mocha` with your test runner everywhere you see it):
 
 ```json
 {
   "scripts": {
-    "test": "npx nyc mocha"
+    "test": "npx nyc@latest mocha"
   }
 }
 ```
 
-Or use your package manager to add a dev dependency: `npm i -D nyc` or `yarn add -D nyc`.
+Or use your package manager to add it as a dev dependency: `npm i -D nyc` or `yarn add -D nyc`.
+You can also use nyc to call npm scripts (assuming they don't already have nyc executed in them), like so:
+```json
+{
+  "scripts": {
+    "test": "mocha",
+    "coverage": "nyc npm run test"
+  }
+}
+```
+
+**Note**: If you use [`jest`](https://npm.im/jest) or [`tap`](https://www.node-tap.org/), you do not need to install `nyc`.
+Those runners already have the IstanbulJS libraries to provide coverage for you.
+Follow their documentation to enable and configure coverage reporting.
 
 ## Configuring `nyc`
 
@@ -50,14 +63,18 @@ Please start with the pre-configured [@istanbuljs/nyc-config-typescript preset](
 
 #### Adding your overrides
 
+nyc allows you to inherit other configurations using the key `extends`.
+You can then add the specific configuration options you want that aren't in that particular shared config, e.g.
 ```json
 {
   "nyc": {
     "extends": "@istanbuljs/nyc-config-typescript",
-    "all": true
+    "all": true,
+    "check-coverage": true
   }
 }
 ```
+
 ### Configuration files
 
 Any configuration options that can be set via the command line can also be specified in the `nyc` stanza of your package.json, or within a seperate configuration file - a variety of flavors are available:
@@ -103,21 +120,22 @@ module.exports = {
 };
 ```
 
-### Publish and reuse your nyc configuration
-
-nyc allows you to inherit other configurations using the key `extends`.
-As an example, an alternative way to configure nyc for `babel-plugin-istanbul` would be to use the [@istanbuljs/nyc-config-babel preset](https://www.npmjs.com/package/@istanbuljs/nyc-config-babel):
-
-```json
-{
-  "nyc": {
-    "extends": "@istanbuljs/nyc-config-babel"
-    //add your custom overrides here
-  }
-}
-```
+### Publish and reuse your nyc configuration(s)
 
 To publish and reuse your own `nyc` configuration, simply create an npm module that exports your JSON config (via [`index.json`](https://github.com/istanbuljs/istanbuljs/blob/master/packages/nyc-config-typescript/) or a CJS [`index.js`](https://github.com/istanbuljs/istanbuljs/blob/master/packages/nyc-config-hook-run-in-this-context/)).
+
+A more advanced use case would be to combine multiple shared in a `nyc.config.js` file:
+```js
+const babelConfig = require('@istanbuljs/nyc-config-babel');
+const hookRunInThisContextConfig = require('@istanbuljs/nyc-config-hook-run-in-this-context');
+
+module.exports = {
+  ...babelConfig,
+  ...hookRunInThisContextConfig,
+  all: true,
+  'check-coverage': true
+};
+```
 
 ## Selecting files for coverage
 
@@ -153,7 +171,7 @@ You can also specify negated paths in the `exclude` array, by prefixing them wit
 Negated paths can restore paths that have been already been excluded in the `exclude` array.
 Multiple `exclude` globs can be specified on the command line, each must follow a `--exclude`, `-x` switch.
 
-The `exclude` option has the following defaults settings:
+The `exclude` option has the following defaults:
 ```js
 [
   'coverage/**',


### PR DESCRIPTION
The intent here is to make the readme much better for newcomers and getting started faster. The major change is promoting the config packages and moving the more advanced features and options towards the bottom. Let me know what you think!

Fixes ...many issues. Hopefully.
Resolves ...many questions. Hopefully.

Easier diff to read: https://github.com/istanbuljs/nyc/tree/82a6dd5