### PR TITLE
fix(cli): Report error if unwanted positional arguments are received

### DIFF
--- a/lib/commands/check-coverage.js
+++ b/lib/commands/check-coverage.js
@@ -7,6 +7,7 @@ exports.describe = 'check whether coverage is within thresholds provided'
 
 exports.builder = function (yargs) {
   yargs
+    .demandCommand(0, 0)
     .option('exclude', {
       alias: 'x',
       default: testExclude.defaultExclude,

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -9,6 +9,15 @@ exports.describe = 'instruments a file or a directory tree and writes the instru
 
 exports.builder = function (yargs) {
   return yargs
+    .demandCommand(0, 0)
+    .positional('input', {
+      describe: 'file or directory to instrument',
+      type: 'text'
+    })
+    .positional('output', {
+      describe: 'directory to output instrumented files',
+      type: 'text'
+    })
     .option('require', {
       alias: 'i',
       default: [],

--- a/lib/commands/merge.js
+++ b/lib/commands/merge.js
@@ -11,6 +11,7 @@ exports.describe = 'merge istanbul format coverage output in a given folder'
 
 exports.builder = function (yargs) {
   return yargs
+    .demandCommand(0, 0)
     .positional('input-directory', {
       describe: 'directory containing multiple istanbul coverage files',
       type: 'text',

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -7,6 +7,7 @@ exports.describe = 'run coverage report for .nyc_output'
 
 exports.builder = function (yargs) {
   return yargs
+    .demandCommand(0, 0)
     .option('reporter', {
       alias: 'r',
       describe: 'coverage reporter(s) to use',

--- a/tap-snapshots/test-nyc-integration.js-TAP.test.js
+++ b/tap-snapshots/test-nyc-integration.js-TAP.test.js
@@ -20,25 +20,6 @@ All files                |    33.33 |        0 |      100 |    33.33 |          
 
 `
 
-exports[`test/nyc-integration.js TAP --check-coverage fails when check-coverage command is used rather than flag > stderr 1`] = `
-ERROR: Coverage for lines (50%) does not meet global threshold (51%)
-
-`
-
-exports[`test/nyc-integration.js TAP --check-coverage fails when check-coverage command is used rather than flag > stdout 1`] = `
------------------|----------|----------|----------|----------|-------------------|
-File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
------------------|----------|----------|----------|----------|-------------------|
-All files        |       50 |       50 |      100 |       50 |                   |
- half-covered.js |       50 |       50 |      100 |       50 |             6,7,8 |
------------------|----------|----------|----------|----------|-------------------|
-
-`
-
-exports[`test/nyc-integration.js TAP --check-coverage fails when check-coverage command is used rather than flag > stdout 2`] = `
-
-`
-
 exports[`test/nyc-integration.js TAP --check-coverage fails when the expected coverage is below a threshold > stderr 1`] = `
 ERROR: Coverage for lines (50%) does not meet global threshold (51%)
 
@@ -307,6 +288,25 @@ BRDA:5,0,1,1
 BRF:2
 BRH:1
 end_of_record
+
+`
+
+exports[`test/nyc-integration.js TAP check-coverage command is equivalent to the flag > stderr 1`] = `
+ERROR: Coverage for lines (50%) does not meet global threshold (51%)
+
+`
+
+exports[`test/nyc-integration.js TAP check-coverage command is equivalent to the flag > stdout 1`] = `
+-----------------|----------|----------|----------|----------|-------------------|
+File             |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
+-----------------|----------|----------|----------|----------|-------------------|
+All files        |       50 |       50 |      100 |       50 |                   |
+ half-covered.js |       50 |       50 |      100 |       50 |             6,7,8 |
+-----------------|----------|----------|----------|----------|-------------------|
+
+`
+
+exports[`test/nyc-integration.js TAP check-coverage command is equivalent to the flag > stdout 2`] = `
 
 `
 

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -45,11 +45,11 @@ t.test('--check-coverage fails when the expected coverage is below a threshold',
 }))
 
 // https://github.com/istanbuljs/nyc/issues/384
-t.test('--check-coverage fails when check-coverage command is used rather than flag', t => {
+t.test('check-coverage command is equivalent to the flag', t => {
   return testSuccess(t, {
     args: [process.execPath, './half-covered.js']
   }).then(() => testFailure(t, {
-    args: ['check-coverage', '--lines', '51', process.execPath, './half-covered.js']
+    args: ['check-coverage', '--lines', '51']
   }))
 })
 


### PR DESCRIPTION
This applies to check-coverage, instrument, merge and report.  Passing
additional arguments will now cause the help script to be displayed and
an error exit code.

Unknown flags `nyc report --unknown=1` are still not reported.
Reporting unknown flags would require additional work as
`yargs.strict()` causes unknown items from configuration to be reported,
including flags that are defined for the global command but not a
sub-command.

Fixes #401

---

Is this a breaking change?  I lean towards no but can see the argument.  Likely this will first be released to 15.0.0 anyways but I'm not sure if it should be noted under breaking changes in the changelog.