### PR TITLE
feat: Add `.cjs`, `.mjs`, `.ts`, `.tsx`, `.jsx` to default extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This table is a quick TLDR for the rest of this readme and there are more advanc
 | ----------- | ----------- | ---- | ------- |
 | `all` | Whether or not to instrument all files (not just the ones touched by your test suite) | `Boolean` | `false` |
 | `check-coverage` | Check whether coverage is within thresholds, fail if not | `Boolean` | `false` |
-| `extension` | List of extensions that nyc should attempt to handle in addition to `.js` | `Array<String>` | `['.js']` |
+| `extension` | List of extensions that nyc should attempt to handle in addition to `.js` | `Array<String>` | `['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx']` |
 | `include` | See [selecting files for coverage] for more info | `Array<String>` | `['**']`|
 | `exclude` | See [selecting files for coverage] for more info | `Array<String>` | [list](https://github.com/istanbuljs/istanbuljs/blob/master/packages/test-exclude/default-exclude.js) |
 | `reporter` | [Coverage reporters to use](https://istanbul.js.org/docs/advanced/alternative-reporters/) | `Array<String>` | `['text']` |
@@ -148,7 +148,7 @@ Only source files that are visited during a test will appear in the coverage rep
 nyc will instrument all files if the `--all` flag is set or if running `nyc instrument`.
 In this case all files will appear in the coverage report and contribute to coverage statistics.
 
-nyc will only collect coverage for files that are located under `cwd`, and then only `*.js` files or files with extensions listed in the `extension` array.
+nyc will only collect coverage for files that are located under `cwd`, and then only files with extensions listed in the `extension` array.
 
 You can reduce the set of instrumented files by adding `include` and `exclude` filter arrays to your config.
 These allow you to shape the set of instrumented files by specifying glob patterns that can filter files from the default instrumented set.

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -25,7 +25,7 @@ exports.builder = function (yargs) {
     })
     .option('extension', {
       alias: 'e',
-      default: [],
+      default: ['.cjs', '.mjs', '.ts', '.tsx', '.jsx'],
       describe: 'a list of extensions that nyc should handle in addition to .js'
     })
     .option('source-map', {

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -49,6 +49,12 @@ exports.builder = function (yargs) {
       describe: 'a list of specific files that should be covered, glob patterns are supported',
       global: false
     })
+    .option('extension', {
+      alias: 'e',
+      default: ['.cjs', '.mjs', '.ts', '.tsx', '.jsx'],
+      describe: 'a list of extensions that nyc should handle in addition to .js',
+      global: false
+    })
     .option('show-process-tree', {
       describe: 'display the tree of spawned processes',
       default: false,

--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -148,7 +148,7 @@ Config.buildYargs = function (cwd) {
     })
     .option('extension', {
       alias: 'e',
-      default: [],
+      default: ['.cjs', '.mjs', '.ts', '.tsx', '.jsx'],
       describe: 'a list of extensions that nyc should handle in addition to .js',
       global: false
     })


### PR DESCRIPTION
Fixes #1103

---

I don't want to pull TypeScript into the devDependencies so I'm not sure if this is going to get testing.  Maybe we could put regular JS into files of these extensions?

The fact that `extension` was missing from the `nyc report` command is minor - only effected the `nyc report --help` output.  Now that the default is non-empty it will matter.  I'd like to look into creating groups of flags - for example a shared function which adds all flags that apply to `test-exclude`.  That is not part of this.