### PR TITLE
chore: Remove test artefacts that can ensure failure on subsequent tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "tap -t360 --no-cov -b test/*.js",
     "snap": "cross-env TAP_SNAPSHOT=1 npm test",
     "posttest": "npm run report",
-    "clean": "rimraf ./.nyc_output ./node_modules/.cache ./.self_coverage ./test/fixtures/.nyc_output ./test/fixtures/node_modules/.cache ./self-coverage",
+    "clean": "rimraf ./.nyc_output ./node_modules/.cache ./.self_coverage ./test/fixtures/.nyc_output ./test/fixtures/node_modules/.cache ./test/fixtures/cli/foo-cache ./test/temp-dir-* ./self-coverage",
     "instrument": "node ./build-self-coverage.js",
     "report": "node ./bin/nyc report --temp-dir ./.self_coverage/ -r text -r lcov",
     "release": "standard-version"


### PR DESCRIPTION
If the tests fail with a bad 'test/fixtures/cli/foo-cache', then subsequent tests will also fail unless the cache is cleaned.
A failed test run also leaves a lot of files in 'test/temp-dir-nyc-integration' that are cleaned on success, but not before the start of the next run in case of failure.