### PR TITLE
feat: Use source base name to prefix cache files

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,9 +93,10 @@ class NYC {
   }
 
   _createTransform (ext) {
-    var opts = {
+    const opts = {
       salt: Hash.salt(this.config),
       hashData: (input, metadata) => [metadata.filename],
+      filenamePrefix: metadata => path.parse(metadata.filename).name + '-',
       onHash: (input, metadata, hash) => {
         this.hashCache[metadata.filename] = hash
       },

--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -11,6 +11,13 @@ function SourceMaps (opts) {
   this._sourceMapCache = libSourceMaps.createSourceMapStore()
 }
 
+SourceMaps.prototype.cachedPath = function (source, hash) {
+  return path.join(
+    this.cacheDirectory,
+    `${path.parse(source).name}-${hash}.map`
+  )
+}
+
 SourceMaps.prototype.purgeCache = function () {
   this._sourceMapCache = libSourceMaps.createSourceMapStore()
   this.loadedMaps = {}
@@ -20,7 +27,7 @@ SourceMaps.prototype.extractAndRegister = function (code, filename, hash) {
   var sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename))
   if (sourceMap) {
     if (this.cache && hash) {
-      var mapPath = path.join(this.cacheDirectory, hash + '.map')
+      const mapPath = this.cachedPath(filename, hash)
       fs.writeFileSync(mapPath, sourceMap.toJSON())
     } else {
       this._sourceMapCache.registerMap(filename, sourceMap.sourcemap)
@@ -43,7 +50,7 @@ SourceMaps.prototype.reloadCachedSourceMaps = function (report) {
       var hash = fileReport.contentHash
       if (!(hash in this.loadedMaps)) {
         try {
-          var mapPath = path.join(this.cacheDirectory, hash + '.map')
+          const mapPath = this.cachedPath(absFile, hash)
           this.loadedMaps[hash] = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
         } catch (e) {
           // set to false to avoid repeatedly trying to load the map

--- a/tap-snapshots/test-nyc-integration.js-TAP.test.js
+++ b/tap-snapshots/test-nyc-integration.js-TAP.test.js
@@ -362,6 +362,26 @@ All files |     100 |      100 |     100 |     100 |
 
 `
 
+exports[`test/nyc-integration.js TAP caches inline source-maps > stdout 1`] = `
+----------|---------|----------|---------|---------|-------------------
+File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+----------|---------|----------|---------|---------|-------------------
+All files |     100 |      100 |     100 |     100 |                   
+ s2.js    |     100 |      100 |     100 |     100 |                   
+----------|---------|----------|---------|---------|-------------------
+
+`
+
+exports[`test/nyc-integration.js TAP caches source-maps from .map files > stdout 1`] = `
+----------|---------|----------|---------|---------|-------------------
+File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+----------|---------|----------|---------|---------|-------------------
+All files |      80 |      100 |      50 |      80 |                   
+ s1.js    |      80 |      100 |      50 |      80 | 7                 
+----------|---------|----------|---------|---------|-------------------
+
+`
+
 exports[`test/nyc-integration.js TAP can run "npm test" which directly invokes a test file > stdout 1`] = `
 
 > @ test .

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -404,6 +404,32 @@ t.test('--all uses source-maps to exclude original sources from reports', t => t
   cwd: fixturesSourceMaps
 }))
 
+t.test('caches source-maps from .map files', t => {
+  return testSuccess(t, {
+    args: [
+      process.execPath,
+      './instrumented/s1.min.js'
+    ],
+    cwd: fixturesSourceMaps
+  }).then(() => {
+    const files = fs.readdirSync(path.resolve(fixturesSourceMaps, 'node_modules/.cache/nyc'))
+    t.true(files.some(f => f.startsWith('s1.min-') && f.endsWith('.map')))
+  })
+})
+
+t.test('caches inline source-maps', t => {
+  return testSuccess(t, {
+    args: [
+      process.execPath,
+      './instrumented/s2.min.js'
+    ],
+    cwd: fixturesSourceMaps
+  }).then(() => {
+    const files = fs.readdirSync(path.resolve(fixturesSourceMaps, 'node_modules/.cache/nyc'))
+    t.true(files.some(f => f.startsWith('s2.min-') && f.endsWith('.map')))
+  })
+})
+
 t.test('appropriately instruments file with corresponding .map file', t => testSuccess(t, {
   args: [
     '--cache=false',


### PR DESCRIPTION
This utilizes a new feature of caching-transform@4 to prefix cache instrumented sources and source-maps with a more useful name.  For example `lib/worker.js` might get cached as `node_modules/.cache/nyc/worker-d84d3c7a86d2657c33e0c6f4fe3013270d7887ae76e3bf14bde6286cffc79b47.js`.  Also added a test to verify creation of the cached source map when appropriate.