### PR TITLE
chore: Suppress coverage for onExit callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,9 +320,11 @@ class NYC {
   _wrapExit () {
     // we always want to write coverage
     // regardless of how the process exits.
-    onExit(() => {
-      this.writeCoverageFile()
-    }, { alwaysLast: true })
+    onExit(
+      /* istanbul ignore next: the callback is run but coverage is not recorded */
+      () => this.writeCoverageFile(),
+      { alwaysLast: true }
+    )
   }
 
   wrap (bin) {


### PR DESCRIPTION
The callback is run but we're unable to record coverage for it.