### PR TITLE
Upgrade lodash to ^4.17.15 to eliminate vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2951,9 +2951,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "chai": "^4.2.0",
     "coveralls": "^3.0.4",
     "is-windows": "^1.0.2",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "requirejs": "^2.3.6",
     "source-map-support": "^0.5.12",
     "standard": "^12.0.1",


### PR DESCRIPTION
This would resolve #1151 to eliminate the npm vulnerability `Prototype Pollution` identified by https://www.npmjs.com/advisories/1065.