### PR TITLE
fix: Drop coverage produced by `nyc --all` for files that were tested

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,11 @@ class NYC {
       const coverage = coverageFinder()
       const lastCoverage = this.instrumenter().lastFileCoverage()
       if (lastCoverage) {
-        coverage[lastCoverage.path] = lastCoverage
+        coverage[lastCoverage.path] = {
+          ...lastCoverage,
+          // Only use this data if we don't have it without `all: true`
+          all: true
+        }
       }
     })
     this.fakeRequire = false

--- a/lib/instrumenters/noop.js
+++ b/lib/instrumenters/noop.js
@@ -1,4 +1,3 @@
-const { FileCoverage } = require('istanbul-lib-coverage').classes
 const { readInitialCoverage } = require('istanbul-lib-instrument')
 
 function NOOP () {
@@ -6,7 +5,7 @@ function NOOP () {
     instrumentSync (code, filename) {
       const extracted = readInitialCoverage(code)
       if (extracted) {
-        this.fileCoverage = new FileCoverage(extracted.coverageData)
+        this.fileCoverage = extracted.coverageData
       } else {
         this.fileCoverage = null
       }


### PR DESCRIPTION
Sometimes the coverage data produced by `nyc --all` is incompatible with
the coverage data produced by actual test runs.  This is generally due
to configuration error but results in inconsistent coverage reports or
in some cases causes `nyc report` to crash.  The workaround is
implemented in istanbul-lib-coverage to drop coverage data associated
with `nyc --all` when coverage data from a test run is found.  This
commit tags the coverage data when appropriate so the coverage merge
logic knows what to do.

Fixes #1113, #1124, #1148