### PR TITLE
chore: Longer delay for stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,3 +1,5 @@
+daysUntilStale: 365
+
 exemptLabels:
   - "Great First Contribution"
   - pinned


### PR DESCRIPTION
The default delay for the stale bot is too aggressive for our ability to
keep up with issues.  This changes from 60 days to 365 days.