### PR TITLE
chore: Modernize lib/source-maps.js

### DIFF
--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -4,64 +4,65 @@ const libSourceMaps = require('istanbul-lib-source-maps')
 const fs = require('fs')
 const path = require('path')
 
-function SourceMaps (opts) {
-  this.cache = opts.cache
-  this.cacheDirectory = opts.cacheDirectory
-  this.loadedMaps = {}
-  this._sourceMapCache = libSourceMaps.createSourceMapStore()
-}
-
-SourceMaps.prototype.cachedPath = function (source, hash) {
-  return path.join(
-    this.cacheDirectory,
-    `${path.parse(source).name}-${hash}.map`
-  )
-}
-
-SourceMaps.prototype.purgeCache = function () {
-  this._sourceMapCache = libSourceMaps.createSourceMapStore()
-  this.loadedMaps = {}
-}
-
-SourceMaps.prototype.extractAndRegister = function (code, filename, hash) {
-  var sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename))
-  if (sourceMap) {
-    if (this.cache && hash) {
-      const mapPath = this.cachedPath(filename, hash)
-      fs.writeFileSync(mapPath, sourceMap.toJSON())
-    } else {
-      this._sourceMapCache.registerMap(filename, sourceMap.sourcemap)
-    }
+class SourceMaps {
+  constructor (opts) {
+    this.cache = opts.cache
+    this.cacheDirectory = opts.cacheDirectory
+    this.loadedMaps = {}
+    this._sourceMapCache = libSourceMaps.createSourceMapStore()
   }
-  return sourceMap
-}
 
-SourceMaps.prototype.remapCoverage = function (obj) {
-  var transformed = this._sourceMapCache.transformCoverage(
-    libCoverage.createCoverageMap(obj)
-  )
-  return transformed.map.data
-}
+  cachedPath (source, hash) {
+    return path.join(
+      this.cacheDirectory,
+      `${path.parse(source).name}-${hash}.map`
+    )
+  }
 
-SourceMaps.prototype.reloadCachedSourceMaps = function (report) {
-  Object.keys(report).forEach((absFile) => {
-    var fileReport = report[absFile]
-    if (fileReport && fileReport.contentHash) {
-      var hash = fileReport.contentHash
-      if (!(hash in this.loadedMaps)) {
-        try {
-          const mapPath = this.cachedPath(absFile, hash)
-          this.loadedMaps[hash] = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
-        } catch (e) {
-          // set to false to avoid repeatedly trying to load the map
-          this.loadedMaps[hash] = false
+  purgeCache () {
+    this._sourceMapCache = libSourceMaps.createSourceMapStore()
+    this.loadedMaps = {}
+  }
+
+  extractAndRegister (code, filename, hash) {
+    const sourceMap = convertSourceMap.fromSource(code) || convertSourceMap.fromMapFileSource(code, path.dirname(filename))
+    if (sourceMap) {
+      if (this.cache && hash) {
+        const mapPath = this.cachedPath(filename, hash)
+        fs.writeFileSync(mapPath, sourceMap.toJSON())
+      } else {
+        this._sourceMapCache.registerMap(filename, sourceMap.sourcemap)
+      }
+    }
+    return sourceMap
+  }
+
+  remapCoverage (obj) {
+    const transformed = this._sourceMapCache.transformCoverage(
+      libCoverage.createCoverageMap(obj)
+    )
+    return transformed.map.data
+  }
+
+  reloadCachedSourceMaps (report) {
+    Object.entries(report).forEach(([absFile, fileReport]) => {
+      if (fileReport && fileReport.contentHash) {
+        const hash = fileReport.contentHash
+        if (!(hash in this.loadedMaps)) {
+          try {
+            const mapPath = this.cachedPath(absFile, hash)
+            this.loadedMaps[hash] = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
+          } catch (e) {
+            // set to false to avoid repeatedly trying to load the map
+            this.loadedMaps[hash] = false
+          }
+        }
+        if (this.loadedMaps[hash]) {
+          this._sourceMapCache.registerMap(absFile, this.loadedMaps[hash])
         }
       }
-      if (this.loadedMaps[hash]) {
-        this._sourceMapCache.registerMap(absFile, this.loadedMaps[hash])
-      }
-    }
-  })
+    })
+  }
 }
 
 module.exports = SourceMaps


### PR DESCRIPTION
* Convert to class
* Prefer const over var
* Use Object.entries()

---

This eliminates the last use of prototype based class declaration in nyc, `git grep prototype` only shows the one place where a test replaces one of the nyc methods.