### PR TITLE
chore: Create npm-run-clean.js script

### DIFF
--- a/npm-run-clean.js
+++ b/npm-run-clean.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+'use strict'
+
+const { promisify } = require('util')
+const rimraf = promisify(require('rimraf'))
+
+Promise.all([
+  '**/.nyc_output',
+  'node_modules/.cache',
+  '.self_coverage',
+  'test/**/.cache',
+  'test/fixtures/cli/coverage',
+  'test/fixtures/cli/fakebin/node',
+  'test/fixtures/cli/fakebin/npm',
+  'test/fixtures/cli/foo-cache',
+  'test/fixtures/cli/nyc-config-js/node_modules',
+  'test/temp-dir-*',
+  'self-coverage'
+].map(f => rimraf(f, { cwd: __dirname })))

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "tap",
     "snap": "npm test -- --snapshot",
     "posttest": "npm run report",
-    "clean": "rimraf ./.nyc_output ./node_modules/.cache ./.self_coverage ./test/fixtures/.nyc_output ./test/fixtures/node_modules/.cache ./test/fixtures/cli/foo-cache ./test/temp-dir-* ./self-coverage",
+    "clean": "node ./npm-run-clean.js",
     "instrument": "node ./build-self-coverage.js",
     "report": "node ./bin/nyc report --temp-dir ./.self_coverage/ -r text -r lcov",
     "release": "standard-version"


### PR DESCRIPTION
This allows use of globs without risk of shell interference, makes it
easier to read the list of delete targets.

---

Maybe `build-self-coverage.js` should be renamed to `npm-run-instrument.js` for consistent naming of `npm run` scripts?