### PR TITLE
fix: Honor eager setting (false by default)

### DIFF
--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const { createInstrumenter } = require('istanbul-lib-instrument')
-const convertSourceMap = require('convert-source-map')
-const mergeSourceMap = require('merge-source-map')
-
 function InstrumenterIstanbul (options) {
+  const { createInstrumenter } = require('istanbul-lib-instrument')
+  const convertSourceMap = require('convert-source-map')
+  const mergeSourceMap = require('merge-source-map')
+
   const { plugins } = options
   const configPlugins = plugins ? { plugins } : {}
 
@@ -28,6 +28,7 @@ function InstrumenterIstanbul (options) {
       // TODO: test source-map merging logic.
       if (options.produceSourceMap) {
         var lastSourceMap = instrumenter.lastSourceMap()
+        /* istanbul ignore else */
         if (lastSourceMap) {
           if (sourceMap) {
             lastSourceMap = mergeSourceMap(

--- a/lib/instrumenters/noop.js
+++ b/lib/instrumenters/noop.js
@@ -1,6 +1,8 @@
-const { readInitialCoverage } = require('istanbul-lib-instrument')
+'use strict'
 
 function NOOP () {
+  const { readInitialCoverage } = require('istanbul-lib-instrument')
+
   return {
     instrumentSync (code, filename) {
       const extracted = readInitialCoverage(code)

--- a/tap-snapshots/test-eager.js-TAP.test.js
+++ b/tap-snapshots/test-eager.js-TAP.test.js
@@ -1,0 +1,16 @@
+/* IMPORTANT
+ * This snapshot file is auto-generated, but designed for humans.
+ * It should be checked into source control and tracked carefully.
+ * Re-generate by setting TAP_SNAPSHOT=1 and running tests.
+ * Make sure to inspect the output below.  Do not ignore changes!
+ */
+'use strict'
+exports[`test/eager.js TAP eager disabled by default > stdout 1`] = `
+0
+
+`
+
+exports[`test/eager.js TAP eager enabled > stdout 1`] = `
+1
+
+`

--- a/test/eager.js
+++ b/test/eager.js
@@ -1,0 +1,30 @@
+'use strict'
+
+const path = require('path')
+
+const t = require('tap')
+
+const { testSuccess } = require('./helpers')
+
+const cwd = path.resolve(__dirname, 'fixtures')
+
+t.test('eager disabled by default', t => testSuccess(t, {
+  args: [
+    '--silent=true',
+    '--exclude=eager.js',
+    process.execPath,
+    './eager.js'
+  ],
+  cwd
+}))
+
+t.test('eager enabled', t => testSuccess(t, {
+  args: [
+    '--silent=true',
+    '--eager=true',
+    '--exclude=eager.js',
+    process.execPath,
+    './eager.js'
+  ],
+  cwd
+}))

--- a/test/fixtures/eager.js
+++ b/test/fixtures/eager.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+'use strict'
+
+const lib = require.resolve('istanbul-lib-instrument')
+console.log(Object.keys(require.cache).filter(s => s === lib).length)


### PR DESCRIPTION
This delays loading of istanbul-lib-instrument until it is needed.

---

This fixes a performance regression caused by #985, adds tests to prevent in the future.  To test you can create a script `eager.js`:
```js
console.log(Object.keys(require.cache).length - 1); // don't count eager.js itself
```

Then you can test the effect of non-eager loading:
```
$ node eager.js
0
$ ./bin/nyc.js --silent --exclude=eager.js --eager=true node eager.js
293
$ ./bin/nyc.js --silent --exclude=eager.js node eager.js
143
```

Running under nyc with `eager: true` (or without this patch) results in 293 additional modules being loaded, this patch by default reduces the "always load" to 143.  This is demonstrated here by ensuring that all sources are excluded from instrument but in practice large test suites that load sources from multiple processes would see benefit when caching-transform bypasses repeated instruments.