### PR TITLE
chore: Use async functions where reasonable

### DIFF
--- a/lib/commands/check-coverage.js
+++ b/lib/commands/check-coverage.js
@@ -1,5 +1,6 @@
 const testExclude = require('test-exclude')
 const NYC = require('../../index.js')
+const cliWrapper = require('./cli-wrapper.js')
 
 exports.command = 'check-coverage'
 
@@ -65,13 +66,14 @@ exports.builder = function (yargs) {
     .example('$0 check-coverage --lines 95', "check whether the JSON in nyc's output folder meets the thresholds provided")
 }
 
-exports.handler = function (argv) {
+exports.handler = cliWrapper(async argv => {
   process.env.NYC_CWD = process.cwd()
 
-  ;(new NYC(argv)).checkCoverage({
+  const nyc = new NYC(argv)
+  await nyc.checkCoverage({
     lines: argv.lines,
     functions: argv.functions,
     branches: argv.branches,
     statements: argv.statements
   }, argv['per-file'])
-}
+})

--- a/lib/commands/cli-wrapper.js
+++ b/lib/commands/cli-wrapper.js
@@ -1,0 +1,10 @@
+'use strict'
+
+module.exports = execute => {
+  return argv => {
+    execute(argv).catch(error => {
+      console.error(error.message)
+      process.exit(1)
+    })
+  }
+}

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -1,7 +1,9 @@
 const NYC = require('../../index.js')
 const path = require('path')
-const rimraf = require('rimraf')
+const { promisify } = require('util')
+const rimraf = promisify(require('rimraf'))
 const testExclude = require('test-exclude')
+const cliWrapper = require('./cli-wrapper.js')
 
 exports.command = 'instrument <input> [output]'
 
@@ -97,30 +99,25 @@ exports.builder = function (yargs) {
     .example('$0 instrument ./lib ./output', 'instrument all .js files in ./lib with coverage and output in ./output')
 }
 
-const errorExit = msg => {
-  console.error(`nyc instrument failed:  ${msg}`)
-  process.exitCode = 1
-}
-
-exports.handler = function (argv) {
+exports.handler = cliWrapper(async argv => {
   if (argv.output && !argv.inPlace && (path.resolve(argv.cwd, argv.input) === path.resolve(argv.cwd, argv.output))) {
-    return errorExit(`cannot instrument files in place, <input> must differ from <output>.  Set '--in-place' to force`)
+    throw new Error(`cannot instrument files in place, <input> must differ from <output>.  Set '--in-place' to force`)
   }
 
   if (path.relative(argv.cwd, path.resolve(argv.cwd, argv.input)).startsWith('..')) {
-    return errorExit('cannot instrument files outside project root directory')
+    throw new Error('cannot instrument files outside project root directory')
   }
 
   if (argv.delete && argv.inPlace) {
-    return errorExit(`cannot use '--delete' when instrumenting files in place`)
+    throw new Error(`cannot use '--delete' when instrumenting files in place`)
   }
 
   if (argv.delete && argv.output && argv.output.length !== 0) {
     const relPath = path.relative(process.cwd(), path.resolve(argv.output))
     if (relPath !== '' && !relPath.startsWith('..')) {
-      rimraf.sync(argv.output)
+      await rimraf(argv.output)
     } else {
-      return errorExit(`attempt to delete '${process.cwd()}' or containing directory.`)
+      throw new Error(`attempt to delete '${process.cwd()}' or containing directory.`)
     }
   }
 
@@ -135,5 +132,5 @@ exports.handler = function (argv) {
   }
 
   const nyc = new NYC(argv)
-  nyc.instrumentAllFiles(argv.input, argv.output, err => err ? errorExit(err.message) : null)
-}
+  await nyc.instrumentAllFiles(argv.input, argv.output)
+})

--- a/lib/commands/merge.js
+++ b/lib/commands/merge.js
@@ -1,7 +1,8 @@
 'use strict'
-const fs = require('fs')
 const path = require('path')
 const makeDir = require('make-dir')
+const fs = require('../fs-promises')
+const cliWrapper = require('./cli-wrapper.js')
 
 const NYC = require('../../index.js')
 
@@ -33,22 +34,18 @@ exports.builder = function (yargs) {
     .example('$0 merge ./out coverage.json', 'merge together reports in ./out and output as coverage.json')
 }
 
-exports.handler = function (argv) {
+exports.handler = cliWrapper(async argv => {
   process.env.NYC_CWD = process.cwd()
   const nyc = new NYC(argv)
-  let inputStat
-  try {
-    inputStat = fs.statSync(argv.inputDirectory)
-    if (!inputStat.isDirectory()) {
-      console.error(`${argv.inputDirectory} was not a directory`)
-      process.exit(1)
-    }
-  } catch (err) {
-    console.error(`failed access input directory ${argv.inputDirectory} with error:\n\n${err.message}`)
-    process.exit(1)
+  const inputStat = await fs.stat(argv.inputDirectory).catch(error => {
+    throw new Error(`failed access input directory ${argv.inputDirectory} with error:\n\n${error.message}`)
+  })
+
+  if (!inputStat.isDirectory()) {
+    throw new Error(`${argv.inputDirectory} was not a directory`)
   }
-  makeDir.sync(path.dirname(argv.outputFile))
-  const map = nyc.getCoverageMapFromAllCoverageFiles(argv.inputDirectory)
-  fs.writeFileSync(argv.outputFile, JSON.stringify(map, null, 2), 'utf8')
+  await makeDir(path.dirname(argv.outputFile))
+  const map = await nyc.getCoverageMapFromAllCoverageFiles(argv.inputDirectory)
+  await fs.writeFile(argv.outputFile, JSON.stringify(map, null, 2), 'utf8')
   console.info(`coverage files in ${argv.inputDirectory} merged into ${argv.outputFile}`)
-}
+})

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -1,5 +1,6 @@
 const testExclude = require('test-exclude')
 const NYC = require('../../index.js')
+const cliWrapper = require('./cli-wrapper.js')
 
 exports.command = 'report'
 
@@ -101,16 +102,16 @@ exports.builder = function (yargs) {
     .example('$0 report --reporter=lcov', 'output an HTML lcov report to ./coverage')
 }
 
-exports.handler = function (argv) {
+exports.handler = cliWrapper(async argv => {
   process.env.NYC_CWD = process.cwd()
   var nyc = new NYC(argv)
-  nyc.report()
+  await nyc.report()
   if (argv.checkCoverage) {
-    nyc.checkCoverage({
+    await nyc.checkCoverage({
       lines: argv.lines,
       functions: argv.functions,
       branches: argv.branches,
       statements: argv.statements
     }, argv['per-file'])
   }
-}
+})

--- a/lib/fs-promises.js
+++ b/lib/fs-promises.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const fs = require('fs')
+
+const { promisify } = require('util')
+
+module.exports = { ...fs }
+
+// Promisify all functions for consistency
+const fns = [
+  'access',
+  'appendFile',
+  'chmod',
+  'chown',
+  'close',
+  'copyFile',
+  'fchmod',
+  'fchown',
+  'fdatasync',
+  'fstat',
+  'fsync',
+  'ftruncate',
+  'futimes',
+  'lchmod',
+  'lchown',
+  'link',
+  'lstat',
+  'mkdir',
+  'mkdtemp',
+  'open',
+  'read',
+  'readdir',
+  'readFile',
+  'readlink',
+  'realpath',
+  'rename',
+  'rmdir',
+  'stat',
+  'symlink',
+  'truncate',
+  'unlink',
+  'utimes',
+  'write',
+  'writeFile'
+]
+fns.forEach(fn => {
+  if (fs[fn]) {
+    module.exports[fn] = promisify(fs[fn])
+  }
+})

--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -1,8 +1,10 @@
 const convertSourceMap = require('convert-source-map')
 const libCoverage = require('istanbul-lib-coverage')
 const libSourceMaps = require('istanbul-lib-source-maps')
-const fs = require('fs')
+const fs = require('./fs-promises')
+const os = require('os')
 const path = require('path')
+const pMap = require('p-map')
 
 class SourceMaps {
   constructor (opts) {
@@ -41,14 +43,42 @@ class SourceMaps {
     this._sourceMapCache.addInputSourceMapsSync(coverage)
   }
 
-  remapCoverage (obj) {
-    const transformed = this._sourceMapCache.transformCoverage(
+  async remapCoverage (obj) {
+    const transformed = await this._sourceMapCache.transformCoverage(
       libCoverage.createCoverageMap(obj)
     )
     return transformed.map.data
   }
 
-  reloadCachedSourceMaps (report) {
+  async reloadCachedSourceMaps (report) {
+    await pMap(
+      Object.entries(report),
+      async ([absFile, fileReport]) => {
+        if (!fileReport || !fileReport.contentHash) {
+          return
+        }
+
+        const hash = fileReport.contentHash
+        if (!(hash in this.loadedMaps)) {
+          try {
+            const mapPath = this.cachedPath(absFile, hash)
+            this.loadedMaps[hash] = JSON.parse(await fs.readFile(mapPath, 'utf8'))
+          } catch (e) {
+            // set to false to avoid repeatedly trying to load the map
+            this.loadedMaps[hash] = false
+          }
+        }
+
+        if (this.loadedMaps[hash]) {
+          this._sourceMapCache.registerMap(absFile, this.loadedMaps[hash])
+        }
+      },
+      { concurrency: os.cpus().length }
+    )
+  }
+
+  /* istanbul ignore next: legacy function for istanbul-lib-processinfo */
+  reloadCachedSourceMapsSync (report) {
     Object.entries(report).forEach(([absFile, fileReport]) => {
       if (fileReport && fileReport.contentHash) {
         const hash = fileReport.contentHash

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,15 @@
       "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
       "dev": true
     },
+    "aggregate-error": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
+      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -500,6 +509,11 @@
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -2344,10 +2358,9 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-      "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -3908,6 +3921,14 @@
         "p-limit": "^2.2.0"
       }
     },
+    "p-map": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "requires": {
+        "aggregate-error": "^3.0.0"
+      }
+    },
     "p-timeout": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
@@ -4315,6 +4336,14 @@
       "requires": {
         "indent-string": "^3.0.0",
         "strip-indent": "^2.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        }
       }
     },
     "regenerator-runtime": {

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "js-yaml": "^3.13.1",
     "make-dir": "^3.0.0",
     "merge-source-map": "^1.1.0",
+    "p-map": "^3.0.0",
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "signal-exit": "^3.0.2",

--- a/tap-snapshots/test-nyc-integration.js-TAP.test.js
+++ b/tap-snapshots/test-nyc-integration.js-TAP.test.js
@@ -502,6 +502,16 @@ All files |       0 |      100 |     100 |       0 |
 `
 
 exports[`test/nyc-integration.js TAP execute with exclude-node-modules=false > stdout 3`] = `
+----------|---------|----------|---------|---------|-------------------
+File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+----------|---------|----------|---------|---------|-------------------
+All files |       0 |      100 |     100 |       0 |                   
+ index.js |       0 |      100 |     100 |       0 | 1                 
+----------|---------|----------|---------|---------|-------------------
+
+`
+
+exports[`test/nyc-integration.js TAP execute with exclude-node-modules=false > stdout 4`] = `
 
 `
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,8 +1,10 @@
 'use strict'
 
 const path = require('path')
+const { promisify } = require('util')
 
 const t = require('tap')
+const rimraf = promisify(require('rimraf'))
 
 const NYC = require('../self-coverage')
 const configUtil = require('../self-coverage/lib/config-util')
@@ -15,7 +17,7 @@ t.beforeEach(resetState)
 
 async function cacheTest (t, script) {
   const nyc = new NYC(configUtil.buildYargs(fixtures).parse())
-  nyc.clearCache()
+  await rimraf(nyc.cacheDirectory)
 
   const { status } = await runNYC({
     args: [

--- a/test/report.js
+++ b/test/report.js
@@ -31,7 +31,7 @@ async function testSignal (t, signal) {
   })
 
   const checkFile = path.join(fixtures, `${signal}.js`)
-  const reports = nyc.loadReports().filter(report => report[checkFile])
+  const reports = (await nyc.coverageData()).filter(report => report[checkFile])
 
   t.strictEqual(reports.length, 1)
 }
@@ -44,9 +44,9 @@ t.test('allows coverage report to be output in an alternative directory', async 
   const nyc = new NYC(configUtil.buildYargs().parse(
     ['--report-dir=./alternative-report', '--reporter=lcov']
   ))
-  nyc.reset()
+  await nyc.reset()
 
-  nyc.report()
+  await nyc.report()
   t.strictEqual(fs.existsSync('./alternative-report/lcov.info'), true)
   await rimraf('./alternative-report')
 })

--- a/test/source-map-support.js
+++ b/test/source-map-support.js
@@ -16,7 +16,7 @@ t.beforeEach(resetState)
 
 t.test('handles stack traces', async t => {
   const nyc = new NYC(configUtil.buildYargs().parse('--produce-source-map'))
-  nyc.reset()
+  await nyc.reset()
   nyc.wrap()
 
   const check = require('./fixtures/stack-trace')
@@ -26,7 +26,7 @@ t.test('handles stack traces', async t => {
 
 t.test('does not handle stack traces when disabled', async t => {
   const nyc = new NYC(configUtil.buildYargs().parse())
-  nyc.reset()
+  await nyc.reset()
   nyc.wrap()
 
   const check = require('./fixtures/stack-trace')

--- a/test/temp-dir.js
+++ b/test/temp-dir.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require('fs')
+const fs = require('../lib/fs-promises')
 const path = require('path')
 const { promisify } = require('util')
 
@@ -8,8 +8,6 @@ const t = require('tap')
 const rimraf = promisify(require('rimraf'))
 
 const { runNYC, fixturesCLI } = require('./helpers')
-
-const readdir = promisify(fs.readdir)
 
 function cleanup () {
   return Promise.all([
@@ -29,12 +27,12 @@ t.test('creates the default \'tempDir\' when none is specified', async t => {
 
   t.strictEqual(status, 0)
 
-  const cliFiles = await readdir(path.resolve(fixturesCLI))
+  const cliFiles = await fs.readdir(path.resolve(fixturesCLI))
   t.strictEqual(cliFiles.includes('.nyc_output'), true)
   t.strictEqual(cliFiles.includes('.temp_dir'), false)
   t.strictEqual(cliFiles.includes('.temp_directory'), false)
 
-  const tempFiles = await readdir(path.resolve(fixturesCLI, '.nyc_output'))
+  const tempFiles = await fs.readdir(path.resolve(fixturesCLI, '.nyc_output'))
   t.strictEqual(tempFiles.length, 2) // the coverage file, and processinfo
 })
 
@@ -52,12 +50,12 @@ t.test('prefers \'tempDirectory\' to \'tempDir\'', async t => {
 
   t.strictEqual(status, 0)
 
-  const cliFiles = await readdir(path.resolve(fixturesCLI))
+  const cliFiles = await fs.readdir(path.resolve(fixturesCLI))
   t.strictEqual(cliFiles.includes('.nyc_output'), false)
   t.strictEqual(cliFiles.includes('.temp_dir'), false)
   t.strictEqual(cliFiles.includes('.temp_directory'), true)
 
-  const tempFiles = await readdir(path.resolve(fixturesCLI, '.temp_directory'))
+  const tempFiles = await fs.readdir(path.resolve(fixturesCLI, '.temp_directory'))
   t.strictEqual(tempFiles.length, 2)
 })
 
@@ -73,11 +71,11 @@ t.test('uses the \'tempDir\' option if \'tempDirectory\' is not set', async t =>
 
   t.strictEqual(status, 0)
 
-  const cliFiles = await readdir(path.resolve(fixturesCLI))
+  const cliFiles = await fs.readdir(path.resolve(fixturesCLI))
   t.strictEqual(cliFiles.includes('.nyc_output'), false)
   t.strictEqual(cliFiles.includes('.temp_dir'), true)
   t.strictEqual(cliFiles.includes('.temp_directory'), false)
 
-  const tempFiles = await readdir(path.resolve(fixturesCLI, '.temp_dir'))
+  const tempFiles = await fs.readdir(path.resolve(fixturesCLI, '.temp_dir'))
   t.strictEqual(tempFiles.length, 2)
 })

--- a/test/wrap.js
+++ b/test/wrap.js
@@ -20,7 +20,7 @@ t.beforeEach(resetState)
 
 t.test('wraps modules with coverage counters when they are required', async t => {
   const nyc = new NYC(configUtil.buildYargs().parse())
-  nyc.reset()
+  await nyc.reset()
   nyc.wrap()
 
   const check = require('./fixtures/check-instrumented')
@@ -37,7 +37,7 @@ t.test('wraps modules with coverage counters when the custom require hook compil
   }
 
   const nyc = new NYC(configUtil.buildYargs().parse())
-  nyc.reset()
+  await nyc.reset()
   nyc.wrap()
 
   // install the custom require hook
@@ -50,7 +50,7 @@ t.test('wraps modules with coverage counters when the custom require hook compil
 
 t.test('assigns a function to custom extensions', async t => {
   const nyc = new NYC(configUtil.buildYargs(configMultExt).parse())
-  nyc.reset()
+  await nyc.reset()
   nyc.wrap()
 
   t.type(require.extensions['.es6'], 'function') // eslint-disable-line
@@ -76,7 +76,7 @@ t.test('calls the `_handleJs` function for custom file extensions', async t => {
     return code
   }
 
-  nyc.reset()
+  await nyc.reset()
   nyc.wrap()
 
   require('./fixtures/conf-multiple-extensions/check-instrumented.es6')
@@ -88,15 +88,15 @@ t.test('calls the `_handleJs` function for custom file extensions', async t => {
 t.test('does not output coverage for files that have not been included, by default', async t => {
   const nyc = new NYC(configUtil.buildYargs(process.cwd()).parse())
   nyc.wrap()
-  nyc.reset()
+  await nyc.reset()
 
-  const reports = nyc.loadReports().filter(report => report['./test/fixtures/not-loaded.js'])
+  const reports = (await nyc.coverageData()).filter(report => report['./test/fixtures/not-loaded.js'])
   t.strictEqual(reports.length, 0)
 })
 
 t.test('tracks coverage appropriately once the file is required', async t => {
   const nyc = new NYC(configUtil.buildYargs(fixtures).parse())
-  nyc.reset()
+  await nyc.reset()
   nyc.wrap()
 
   require('./fixtures/not-loaded')
@@ -104,7 +104,7 @@ t.test('tracks coverage appropriately once the file is required', async t => {
   nyc.writeCoverageFile()
 
   const notLoadedPath = path.join(fixtures, './not-loaded.js')
-  const reports = nyc.loadReports().filter(report => report[notLoadedPath])
+  const reports = (await nyc.coverageData()).filter(report => report[notLoadedPath])
   const report = reports[0][notLoadedPath]
 
   t.strictEqual(reports.length, 1)


### PR DESCRIPTION
Might be missing a couple places but I wanted to be careful to avoid stuff that is used by the `signal-exit` callback.