### PR TITLE
chore: Coverage for signal-exit handler.

### DIFF
--- a/self-coverage-helper.js
+++ b/self-coverage-helper.js
@@ -5,16 +5,25 @@ const fs = require('fs')
 const mkdirp = require('make-dir')
 const onExit = require('signal-exit')
 
-onExit(function () {
-  var coverage = global.___NYC_SELF_COVERAGE___
-  if (typeof ___NYC_SELF_COVERAGE___ === 'object') coverage = ___NYC_SELF_COVERAGE___
-  if (!coverage) return
+module.exports = {
+  registered: false,
+  onExit () {
+    const coverage = ___NYC_SELF_COVERAGE___
 
-  var selfCoverageDir = path.join(__dirname, '.self_coverage')
-  mkdirp.sync(selfCoverageDir)
-  fs.writeFileSync(
-    path.join(selfCoverageDir, process.pid + '.json'),
-    JSON.stringify(coverage),
-    'utf-8'
-  )
+    const selfCoverageDir = path.join(__dirname, '.self_coverage')
+    mkdirp.sync(selfCoverageDir)
+    fs.writeFileSync(
+      path.join(selfCoverageDir, process.pid + '.json'),
+      JSON.stringify(coverage),
+      'utf-8'
+    )
+  }
+}
+
+onExit(() => {
+  if (module.exports.registered) {
+    return
+  }
+
+  module.exports.onExit()
 })


### PR DESCRIPTION
This allows us to record coverage for all code called from the
signal-exit handler.