### PR TITLE
fix: Avoid `source-map` module during `signal-exit` handler

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,7 +369,7 @@ class NYC {
         }
       }, this)
     } else {
-      coverage = this.sourceMaps.remapCoverage(coverage)
+      this.sourceMaps.addSourceMaps(coverage)
     }
 
     var id = this.processInfo.uuid

--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -37,6 +37,10 @@ class SourceMaps {
     return sourceMap
   }
 
+  addSourceMaps (coverage) {
+    this._sourceMapCache.addInputSourceMapsSync(coverage)
+  }
+
   remapCoverage (obj) {
     const transformed = this._sourceMapCache.transformCoverage(
       libCoverage.createCoverageMap(obj)


### PR DESCRIPTION
Prior to this change child processes would call upon the source-map
module to remap coverage during the `signal-exit` handler.  This was a
blocker for updating `source-map` to 0.7.x which uses an async
constructor method.

Now we simply save the source-map with the raw coverage data for each
file.  This allows the main nyc process to perform source-map remapping.
The benefit is that the main nyc process can use async code.