### PR TITLE
docs: `npm home nyc` goes to github master branch README

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
   "engines": {
     "node": ">=8"
   },
+  "homepage": "https://istanbul.js.org/",
   "repository": {
     "type": "git",
     "url": "git@github.com:istanbuljs/nyc.git"


### PR DESCRIPTION
This causes confusion among users who think they're reading about the
latest releaase.  It is better that we send users to istanbul.js.org for
documentation.

Issue #1200

---

@bcoe another option would be to use https://npmjs.com/packages/nyc as the homepage.  I'm fine with either one.