### PR TITLE
Add support for relative path option

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ class NYC {
     this._showProcessTree = config.showProcessTree || false
     this._eagerInstantiation = config.eager || false
     this.cwd = config.cwd || process.cwd()
-    this.projectRoot = config.projectRoot || this.cwd
     this.reporter = [].concat(config.reporter || 'text')
 
     this.cacheDirectory = (config.cacheDir && path.resolve(config.cacheDir)) || findCacheDir({ name: 'nyc', cwd: this.cwd })
@@ -441,7 +440,7 @@ class NYC {
       reports.create(_reporter, {
         skipEmpty: this.config.skipEmpty,
         skipFull: this.config.skipFull,
-        projectRoot: this.projectRoot,
+        projectRoot: this.cwd,
         maxCols: process.stdout.columns || 100
       }).execute(context)
     })

--- a/index.js
+++ b/index.js
@@ -428,6 +428,7 @@ class NYC {
       reports.create(_reporter, {
         skipEmpty: this.config.skipEmpty,
         skipFull: this.config.skipFull,
+        relative: this.config.relative === 'true',
         maxCols: process.stdout.columns || 100
       }).execute(context)
     })

--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ class NYC {
     this._showProcessTree = config.showProcessTree || false
     this._eagerInstantiation = config.eager || false
     this.cwd = config.cwd || process.cwd()
+    this.projectRoot = config.projectRoot || this.cwd
     this.reporter = [].concat(config.reporter || 'text')
 
     this.cacheDirectory = (config.cacheDir && path.resolve(config.cacheDir)) || findCacheDir({ name: 'nyc', cwd: this.cwd })
@@ -440,7 +441,7 @@ class NYC {
       reports.create(_reporter, {
         skipEmpty: this.config.skipEmpty,
         skipFull: this.config.skipFull,
-        relative: this.config.relative === 'true',
+        projectRoot: this.projectRoot,
         maxCols: process.stdout.columns || 100
       }).execute(context)
     })


### PR DESCRIPTION
Add the possibility to use --relative=true option in command line
This is useful if you run your test on a linux environment (docker, vm, server) and dev on a windows one.
If you want your coverage to work with your IDE, you need relative path instead of absolute ones.

Linked with pull request https://github.com/istanbuljs/istanbuljs/pull/492