### PR TITLE
Add enterprise language

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,9 @@ Please feel free to [contribute documentation](https://github.com/istanbuljs/ist
 [`babel-plugin-istanbul`]: https://github.com/istanbuljs/babel-plugin-istanbul
 [`@istanbuljs/nyc-config-babel`]: https://www.npmjs.com/package/@istanbuljs/nyc-config-babel
 [selecting files for coverage]: #selecting-files-for-coverage
+
+## `nyc` for enterprise
+
+Available as part of the Tidelift Subscription.
+
+The maintainers of `nyc` and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm-nyc?utm_source=npm-nyc&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)

--- a/README.md
+++ b/README.md
@@ -377,13 +377,13 @@ See [more nyc tutorials](https://istanbul.js.org/docs/tutorials) and [advanced n
 
 Please feel free to [contribute documentation](https://github.com/istanbuljs/istanbuljs.github.io/tree/development/content) to help us improve.
 
-[`@babel/register`]: https://www.npmjs.com/package/@babel/register
-[`babel-plugin-istanbul`]: https://github.com/istanbuljs/babel-plugin-istanbul
-[`@istanbuljs/nyc-config-babel`]: https://www.npmjs.com/package/@istanbuljs/nyc-config-babel
-[selecting files for coverage]: #selecting-files-for-coverage
-
 ## `nyc` for enterprise
 
 Available as part of the Tidelift Subscription.
 
 The maintainers of `nyc` and thousands of other packages are working with Tidelift to deliver commercial support and maintenance for the open source dependencies you use to build your applications. Save time, reduce risk, and improve code health, while paying the maintainers of the exact dependencies you use. [Learn more.](https://tidelift.com/subscription/pkg/npm-nyc?utm_source=npm-nyc&utm_medium=referral&utm_campaign=enterprise&utm_term=repo)
+
+[`@babel/register`]: https://www.npmjs.com/package/@babel/register
+[`babel-plugin-istanbul`]: https://github.com/istanbuljs/babel-plugin-istanbul
+[`@istanbuljs/nyc-config-babel`]: https://www.npmjs.com/package/@istanbuljs/nyc-config-babel
+[selecting files for coverage]: #selecting-files-for-coverage


### PR DESCRIPTION
This adds the enterprise language for Tidelift with the nyc tracking code.

I think we should use this in the base of the `istanbuljs` repo too.

@coreyfarrell @bcoe Any objections to me adding a "For Enterprise" page to the website?