### PR TITLE
chore: Remove unused functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -501,28 +501,6 @@ class NYC {
     )
   }
 
-  /* istanbul ignore next: legacy function used by istanbul-lib-processinfo. */
-  eachReport (filenames, iterator, baseDirectory) {
-    baseDirectory = baseDirectory || this.tempDirectory()
-
-    const files = filenames || fs.readdirSync(baseDirectory)
-    files.forEach(f => {
-      var report
-      try {
-        report = JSON.parse(fs.readFileSync(
-          path.resolve(baseDirectory, f),
-          'utf-8'
-        ))
-
-        this.sourceMaps.reloadCachedSourceMapsSync(report)
-      } catch (e) { // handle corrupt JSON output.
-        report = {}
-      }
-
-      iterator(report)
-    })
-  }
-
   tempDirectory () {
     return path.resolve(this.cwd, this._tempDirectory)
   }

--- a/lib/source-maps.js
+++ b/lib/source-maps.js
@@ -79,27 +79,6 @@ class SourceMaps {
       { concurrency: os.cpus().length }
     )
   }
-
-  /* istanbul ignore next: legacy function for istanbul-lib-processinfo */
-  reloadCachedSourceMapsSync (report) {
-    Object.entries(report).forEach(([absFile, fileReport]) => {
-      if (fileReport && fileReport.contentHash) {
-        const hash = fileReport.contentHash
-        if (!(hash in this.loadedMaps)) {
-          try {
-            const mapPath = this.cachedPath(absFile, hash)
-            this.loadedMaps[hash] = JSON.parse(fs.readFileSync(mapPath, 'utf8'))
-          } catch (e) {
-            // set to false to avoid repeatedly trying to load the map
-            this.loadedMaps[hash] = false
-          }
-        }
-        if (this.loadedMaps[hash]) {
-          this._sourceMapCache.registerMap(absFile, this.loadedMaps[hash])
-        }
-      }
-    })
-  }
 }
 
 module.exports = SourceMaps


### PR DESCRIPTION
A couple of sync functions were left behind for a previous version of
istanbul-lib-processinfo.  These functions are no longer used so they
are removed.