### PR TITLE
chore: Fix 404 in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This table is a quick TLDR for the rest of this readme and there are more advanc
 | `check-coverage` | Check whether coverage is within thresholds, fail if not | `Boolean` | `false` |
 | `extension` | List of extensions that nyc should attempt to handle in addition to `.js` | `Array<String>` | `['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx']` |
 | `include` | See [selecting files for coverage] for more info | `Array<String>` | `['**']`|
-| `exclude` | See [selecting files for coverage] for more info | `Array<String>` | [list](https://github.com/istanbuljs/istanbuljs/blob/master/packages/test-exclude/default-exclude.js) |
+| `exclude` | See [selecting files for coverage] for more info | `Array<String>` | [list](https://github.com/istanbuljs/schema/blob/master/default-exclude.js) |
 | `reporter` | [Coverage reporters to use](https://istanbul.js.org/docs/advanced/alternative-reporters/) | `Array<String>` | `['text']` |
 | `report-dir` | Where to put the coverage report files | `String` | `./coverage` |
 | `skip-full` | Don't show files with 100% statement, branch, and function coverage | `Boolean` | `false` |
@@ -109,7 +109,7 @@ This table is a quick TLDR for the rest of this readme and there are more advanc
 Configuration can also be provided by `nyc.config.js` if programmed logic is required:
 ```js
 'use strict';
-const {defaultExclude} = require('test-exclude');
+const defaultExclude = require('@istanbuljs/schema/default-exclude');
 const isWindows = require('is-windows');
 
 let platformExclude = [


### PR DESCRIPTION
default-exclude list has moved, missed a link in #1214.

Fixes #1219