### PR TITLE
fix: Better error handling for main execution, reporting

### DIFF
--- a/lib/commands/check-coverage.js
+++ b/lib/commands/check-coverage.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const NYC = require('../../index.js')
-const { cliWrapper, setupOptions } = require('./helpers.js')
+const { cliWrapper, suppressEPIPE, setupOptions } = require('./helpers.js')
 
 exports.command = 'check-coverage'
 
@@ -24,5 +24,5 @@ exports.handler = cliWrapper(async argv => {
     functions: argv.functions,
     branches: argv.branches,
     statements: argv.statements
-  }, argv['per-file'])
+  }, argv['per-file']).catch(suppressEPIPE)
 })

--- a/lib/commands/helpers.js
+++ b/lib/commands/helpers.js
@@ -50,10 +50,23 @@ module.exports = {
       }
     })
   },
+  /* istanbul ignore next: unsure how to test this */
+  suppressEPIPE (error) {
+    /* Prevent dumping error when `nyc npm t|head` causes stdout to
+     * be closed when reporting runs. */
+    if (error.code !== 'EPIPE') {
+      throw error
+    }
+  },
   cliWrapper (execute) {
     return argv => {
       execute(argv).catch(error => {
-        console.error(error.message)
+        try {
+          console.error(error.message)
+        } catch (_) {
+          /* We need to run process.exit(1) even if stderr is destroyed */
+        }
+
         process.exit(1)
       })
     }

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const NYC = require('../../index.js')
-const { cliWrapper, setupOptions } = require('./helpers.js')
+const { cliWrapper, suppressEPIPE, setupOptions } = require('./helpers.js')
 
 exports.command = 'report'
 
@@ -18,13 +18,13 @@ exports.builder = function (yargs) {
 exports.handler = cliWrapper(async argv => {
   process.env.NYC_CWD = process.cwd()
   var nyc = new NYC(argv)
-  await nyc.report()
+  await nyc.report().catch(suppressEPIPE)
   if (argv.checkCoverage) {
     await nyc.checkCoverage({
       lines: argv.lines,
       functions: argv.functions,
       branches: argv.branches,
       statements: argv.statements
-    }, argv['per-file'])
+    }, argv['per-file']).catch(suppressEPIPE)
   }
 })


### PR DESCRIPTION
This mainly deals with situations such as `nyc node ./script.js | head -n1` where stdout is closed before nyc tries to print reports.  15.0.0-beta.1 currently has an unhandled rejection when this happens in main execution.