### PR TITLE
chore: Remove cp-file module

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 /* global __coverage__ */
 
 const cachingTransform = require('caching-transform')
-const cpFile = require('cp-file')
 const findCacheDir = require('find-cache-dir')
 const fs = require('./lib/fs-promises')
 const os = require('os')
@@ -225,13 +224,23 @@ class NYC {
 
       const concurrency = output ? os.cpus().length : 1
       if (this.config.completeCopy && output) {
+        const files = await glob(path.resolve(input, '**'), {
+          dot: true,
+          nodir: true,
+          ignore: ['**/.git', '**/.git/**', path.join(output, '**')]
+        })
+        const destDirs = new Set(
+          files.map(src => path.dirname(path.join(output, path.relative(input, src))))
+        )
+
         await pMap(
-          await glob(path.resolve(input, '**'), {
-            dot: true,
-            nodir: true,
-            ignore: ['**/.git', '**/.git/**', path.join(output, '**')]
-          }),
-          src => cpFile(src, path.join(output, path.relative(input, src))),
+          destDirs,
+          dir => mkdirp(dir),
+          { concurrency }
+        )
+        await pMap(
+          files,
+          src => fs.copyFile(src, path.join(output, path.relative(input, src))),
           { concurrency }
         )
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1165,17 +1165,6 @@
         "request": "^2.86.0"
       }
     },
-    "cp-file": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-7.0.0.tgz",
-      "integrity": "sha512-0Cbj7gyvFVApzpK/uhCtQ/9kE9UnYpxMzaq5nQQC/Dh4iaj5fxp7iEFIullrYwzj8nf0qnsI1Qsx34hAeAebvw==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^3.0.0",
-        "nested-error-stacks": "^2.0.0",
-        "p-event": "^4.1.0"
-      }
-    },
     "cross-spawn": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
@@ -3743,7 +3732,8 @@
     "nested-error-stacks": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
+      "dev": true
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4428,19 +4418,6 @@
         "own-or": "^1.0.0"
       }
     },
-    "p-event": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.1.0.tgz",
-      "integrity": "sha512-4vAd06GCsgflX4wHN1JqrMzBh/8QZ4j+rzp0cd2scXRwuBEv+QR3wrVA5aLhWDLw4y2WgDKvzWF3CCLmVM1UgA==",
-      "requires": {
-        "p-timeout": "^2.0.1"
-      }
-    },
-    "p-finally": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
-    },
     "p-limit": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
@@ -4463,14 +4440,6 @@
       "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
       "requires": {
         "aggregate-error": "^3.0.0"
-      }
-    },
-    "p-timeout": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
-      "requires": {
-        "p-finally": "^1.0.0"
       }
     },
     "p-try": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@istanbuljs/schema": "^0.1.1",
     "caching-transform": "^4.0.0",
     "convert-source-map": "^1.7.0",
-    "cp-file": "^7.0.0",
     "decamelize": "^1.2.0",
     "find-cache-dir": "=3.0.0",
     "find-up": "^4.1.0",
@@ -96,7 +95,7 @@
     "which": "^2.0.1"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=8.9"
   },
   "homepage": "https://istanbul.js.org/",
   "repository": {

--- a/test/instrument.js
+++ b/test/instrument.js
@@ -6,7 +6,6 @@ const { promisify } = require('util')
 
 const t = require('tap')
 const makeDir = require('make-dir')
-const cpFile = require('cp-file')
 const isWindows = require('is-windows')()
 const rimraf = promisify(require('rimraf'))
 
@@ -243,7 +242,7 @@ t.test('can write files in place with --in-place switch', async t => {
   const sourceDir = path.resolve(fixturesCLI, 'instrument-inplace')
   await makeDir(outputDir)
   await Promise.all(['package.json', 'file1.js', 'file2.js'].map(
-    file => cpFile(path.join(sourceDir, file), path.join(outputDir, file))
+    file => fs.copyFile(path.join(sourceDir, file), path.join(outputDir, file))
   ))
 
   const { status } = await runNYC({


### PR DESCRIPTION
This slightly reduces the amount of code nyc loads by using the core
fs.copyFile function.  Clarify `package.json#engines` to show that
node.js 8.9.0 (LTS) is the oldest supported release.