### PR TITLE
(chore) Remove the unused uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,15 +72,14 @@
     "istanbul-lib-source-maps": "^4.0.0",
     "istanbul-reports": "^3.0.0",
     "make-dir": "^3.0.0",
+    "node-preload": "^0.2.0",
     "p-map": "^3.0.0",
     "process-on-spawn": "^1.0.0",
-    "node-preload": "^0.2.0",
     "resolve-from": "^5.0.0",
     "rimraf": "^3.0.0",
     "signal-exit": "^3.0.2",
     "spawn-wrap": "^2.0.0",
     "test-exclude": "^6.0.0",
-    "uuid": "^3.3.3",
     "yargs": "^15.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This seems to be included in istanbul-lib-processinfo, but please confirm.