### PR TITLE
(fix) Conditionally set `envPath.APPDATA`

### DIFF
--- a/test/helpers/run-nyc.js
+++ b/test/helpers/run-nyc.js
@@ -7,6 +7,12 @@ const envPath = {
   PATH: process.env.PATH
 }
 
+// Work around a Windows issue with `APPDATA`,
+// https://github.com/istanbuljs/nyc/issues/1248
+if ('APPDATA' in process.env) {
+  envPath.APPDATA = process.env.APPDATA
+}
+
 function sanitizeString (str, cwd, leavePathSep) {
   /*
    * File paths are different on different systems:


### PR DESCRIPTION
Fixes test failures on Windows.

Fixes #1248 

@coreyfarrell I used your author info, feel free to tweak the commit message when merging.