### PR TITLE
(chore) Switch to AppVeyor for Windows testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,11 @@
 language: node_js
 os:
-  - windows
   - linux
   - osx
 node_js:
   - "node"
   - 10
   - 8
-matrix:
-## An ENOMEM error occurs with 10+ under Travis-CI for Windows.
-## Disable until we can determine the cause.
-#  include:
-#    - os: windows
-#      node_js: "latest"
-  exclude:
-    - os: windows
-      node_js: "node"
-    - os: windows
-      node_js: 10
 git:
   depth:
     1

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # nyc
 
-[![Build Status](https://travis-ci.org/istanbuljs/nyc.svg?branch=master)](https://travis-ci.org/istanbuljs/nyc)
-[![Coverage Status](https://coveralls.io/repos/istanbuljs/nyc/badge.svg?branch=)](https://coveralls.io/r/istanbuljs/nyc?branch=master)
+[![Build Status](https://img.shields.io/travis/istanbuljs/nyc/master.svg)](https://travis-ci.org/istanbuljs/nyc)
+[![Windows Build Status](https://img.shields.io/appveyor/ci/istanbuljs/nyc/master.svg?label=Windows%20build)](https://ci.appveyor.com/project/istanbuljs/nyc/branch/master)
+[![Coverage Status](https://img.shields.io/coveralls/github/istanbuljs/nyc/master.svg)](https://coveralls.io/r/istanbuljs/nyc?branch=master)
 [![NPM version](https://img.shields.io/npm/v/nyc.svg)](https://www.npmjs.com/package/nyc)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![community slack](https://devtoolscommunity.herokuapp.com/badge.svg)](https://devtoolscommunity.herokuapp.com)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,31 @@
+version: "{build}"
+
+shallow_clone: true
+
+environment:
+  matrix:
+    - NODEJS_VERSION: "13"
+      PLATFORM: x64
+    - NODEJS_VERSION: "12"
+      PLATFORM: x64
+    - NODEJS_VERSION: "10"
+      PLATFORM: x64
+    - NODEJS_VERSION: "8"
+      PLATFORM: x64
+
+install:
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:NODEJS_VERSION) $env:PLATFORM
+  - npm ci
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off
+
+matrix:
+  fast_finish: true
+
+cache:
+  - '%APPDATA%\npm-cache\ -> appveyor.yml,package.json,package-lock.json'


### PR DESCRIPTION
@coreyfarrell the only changes you should make in AppVeyor settings are these:

* Skip branches without appveyor.yml
* Save build cache in Pull Requests

Notes:

- [x] we could always install the latest version of Node.js; if you want this let me know
- [x] I haven't added Node.js 13, should I add it?
- [x] I test one x86 build and everything else x64. I don't think it matters, so maybe I should just use x64 for all versions?
- [x] I have added caching (caching the global npm folder) which will be invalidated if any of these files changes: appveyor.yml, package.json, package-lock.json
