### PR TITLE
(chore) Update node-preload to v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3747,9 +3747,9 @@
       "dev": true
     },
     "node-preload": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.0.tgz",
-      "integrity": "sha512-aiMX5GZLbaMZWF+Eh34RrUyJdg8QecZgxHUmpHVb/6RUna7q4WYAoeH16dJmEIeF7YhAMtwtbUpYCxUYpsMetg==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
       "requires": {
         "process-on-spawn": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "istanbul-lib-source-maps": "^4.0.0",
     "istanbul-reports": "^3.0.0",
     "make-dir": "^3.0.0",
-    "node-preload": "^0.2.0",
+    "node-preload": "^0.2.1",
     "p-map": "^3.0.0",
     "process-on-spawn": "^1.0.0",
     "resolve-from": "^5.0.0",


### PR DESCRIPTION
It's my understanding that v0.2.1 has some important fixes.