### PR TITLE
Add `baseline` switch to `nyc instrument` command

### DIFF
--- a/docs/instrument.md
+++ b/docs/instrument.md
@@ -18,6 +18,9 @@ nyc instrument <input> [output]
 The `[output]` directory is optional and can be located anywhere, if not set the instrumented code will be sent to `stdout`.
 For example, `nyc instrument . ./output` will produce instrumented versions of any source files it finds in `.` and store them in `./output`.
 
+The `--baseline` option will save a baseline coverage file to `<temp-dir>/baseline/coverage.json`.
+Include this file when reporting to highlight files with no test coverage.
+
 The `--delete` option will remove the existing output directory before instrumenting.
 
 The `--in-place` option will allow you to run the instrument command.

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ class NYC {
 
     this.subprocessBin = config.subprocessBin || path.resolve(__dirname, './bin/nyc.js')
     this._tempDirectory = config.tempDirectory || config.tempDir || './.nyc_output'
+    this._baselineDirectoryName = 'baseline'
     this._instrumenterLib = require(config.instrumenter || './lib/instrumenters/istanbul')
     this._reportDir = config.reportDir || 'coverage'
     this._sourceMap = typeof config.sourceMap === 'boolean' ? config.sourceMap : true
@@ -170,7 +171,7 @@ class NYC {
     return source
   }
 
-  async addAllFiles () {
+  async addAllFiles (coverageFilename) {
     this._loadAdditionalModules()
 
     this.fakeRequire = true
@@ -190,7 +191,7 @@ class NYC {
     })
     this.fakeRequire = false
 
-    this.writeCoverageFile()
+    this.writeCoverageFile(coverageFilename)
   }
 
   async instrumentAllFiles (input, output) {
@@ -335,6 +336,10 @@ class NYC {
       await mkdirp(this.cacheDirectory)
     }
 
+    if (this.config.baseline) {
+      await mkdirp(this.baselineDirectory())
+    }
+
     await mkdirp(this.processInfo.directory)
   }
 
@@ -374,26 +379,25 @@ class NYC {
     return this
   }
 
-  writeCoverageFile () {
-    var coverage = coverageFinder()
+  writeCoverageFile (filename = this.processInfo.uuid) {
+    const coverage = coverageFinder()
 
     // Remove any files that should be excluded but snuck into the coverage
-    Object.keys(coverage).forEach(function (absFile) {
+    Object.keys(coverage).forEach(absFile => {
       if (!this.exclude.shouldInstrument(absFile)) {
         delete coverage[absFile]
       }
-    }, this)
+    })
 
     if (this.cache) {
-      Object.keys(coverage).forEach(function (absFile) {
+      Object.keys(coverage).forEach(absFile => {
         if (this.hashCache[absFile] && coverage[absFile]) {
           coverage[absFile].contentHash = this.hashCache[absFile]
         }
-      }, this)
+      })
     }
 
-    var id = this.processInfo.uuid
-    var coverageFilename = path.resolve(this.tempDirectory(), id + '.json')
+    const coverageFilename = path.resolve(this.tempDirectory(), `${filename}.json`)
 
     fs.writeFileSync(
       coverageFilename,
@@ -514,6 +518,10 @@ class NYC {
 
   tempDirectory () {
     return path.resolve(this.cwd, this._tempDirectory)
+  }
+
+  baselineDirectory () {
+    return path.resolve(this.cwd, this._tempDirectory, this._baselineDirectoryName)
   }
 
   reportDirectory () {

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -59,5 +59,14 @@ exports.handler = cliWrapper(async argv => {
     })
   }
 
+  if (argv.baseline) {
+    if (argv.clean) {
+      await nyc.reset()
+    } else {
+      await nyc.createTempDirectory()
+    }
+    await nyc.addAllFiles('baseline/coverage')
+  }
+
   await nyc.instrumentAllFiles(argv.input, argv.output)
 })


### PR DESCRIPTION
Adds the switch `--baseline` that creates a baseline coverage file when running `nyc instrument ...`.
The baseline coverage files is saved to `<temp-dir>/baseline/coverage.json`.
The baseline coverage file saves the zero coverage state for all files specified by your configuration.
Include this file when reporting to highlight source files with no coverage.

Note that  `<temp-dir>/baseline/coverage.json` isn't automatically included when running `nyc report`.
However this might not be such an issue when running nyc for instrumentation and reporting only.