### PR TITLE
feat: Add support for caching with the `nyc instrument` command

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ class NYC {
   }
 
   _disableCachingTransform () {
-    return !(this.cache && this.config.isChildProcess)
+    return !(this.cache && (this.config.isChildProcess || this.config.nycInstrumentCache))
   }
 
   _loadAdditionalModules () {

--- a/lib/commands/instrument.js
+++ b/lib/commands/instrument.js
@@ -51,6 +51,8 @@ exports.handler = cliWrapper(async argv => {
     argv.completeCopy = false
   }
 
+  argv.nycInstrumentCache = true
+
   const nyc = new NYC(argv)
   if (!argv.useSpawnWrap) {
     nyc.require.forEach(requireModule => {


### PR DESCRIPTION
This is a simple change to add cache support to `nyc instrument`.
It has a prerequisite PR [here](https://github.com/istanbuljs/schema/pull/9)

As discussed previously this will probably need some kind of mechanism to clear the cache if the user changes the how `nyc` behaves with require hooks.  I'm open to ideas on how to achieve this.