### PR TITLE
fix: A test where nyc output help text to stderr was flaky

### DIFF
--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -294,7 +294,7 @@ t.test('nyc displays help to stderr when it doesn\'t know what to do', async t =
 
   t.equal(status, 1)
   t.equal(stdout, '')
-  t.equal(stderr, help.stdout)
+  t.match(stderr, help.stdout)
 })
 
 t.test('handles --clean / --no-clean properly', async t => {


### PR DESCRIPTION
This change allows for flaky output of help information from `yargs` to `stderr` when running `nyc` as a child process.

Fixes #1259.