### PR TITLE
Data merge concurrency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/build/
 self-coverage/
 *.swp
 needs-transpile.js
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ test/build/
 self-coverage/
 *.swp
 needs-transpile.js
-/.idea

--- a/index.js
+++ b/index.js
@@ -508,6 +508,7 @@ class NYC {
     }
   }
 
+  // TODO: Remove from nyc v16
   async coverageData (baseDirectory) {
     const files = await this.coverageFiles(baseDirectory)
     return pMap(

--- a/index.js
+++ b/index.js
@@ -408,11 +408,16 @@ class NYC {
 
   async getCoverageMapFromAllCoverageFiles (baseDirectory) {
     const map = libCoverage.createCoverageMap({})
+    const files = await this.coverageFiles(baseDirectory)
 
-    const data = await this.coverageData(baseDirectory)
-    data.forEach(report => {
-      map.merge(report)
-    })
+    await pMap(
+      files,
+      async f => {
+        const report = await this.coverageFileLoad(f, baseDirectory)
+        map.merge(report)
+      },
+      { concurrency: os.cpus().length }
+    )
 
     map.data = await this.sourceMaps.remapCoverage(map.data)
 


### PR DESCRIPTION
This PR fixes https://github.com/istanbuljs/nyc/issues/1263

Instead of fetching all reports into memory and then merging, we do that one-by-one.