### PR TITLE
feat: support passing `--reporter-options` to nyc's own reporters

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,6 +446,7 @@ class NYC {
       reports.create(_reporter, {
         skipEmpty: this.config.skipEmpty,
         skipFull: this.config.skipFull,
+        reporterOptions: this.config.reporterOptions,
         projectRoot: this.cwd,
         maxCols: process.stdout.columns || 100
       }).execute(context)


### PR DESCRIPTION
This aims to allow nyc reporters to receive config (without need for setting environmental variables).

My own interest is in building a reporter which can output, for example, the top 10 visited lines of a file or project. I'd like for users to be able to pass in config which can control how much is listed, what information, etc.

If it is ok, maybe I could adapt this so that the reporter could even get the entire `config` object (e.g., if I adapted the badge-making tool I created, [coveradge](https://www.npmjs.com/package/coveradge), to work as a reporter, I could immediately detect the user's thresholds, e.g., `statements`, without having to re-query them).