### PR TITLE
feat(experimental): Support using `--all` with node.js ES modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2248,6 +2248,11 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
+    },
     "get-pkg-repo": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/get-pkg-repo/-/get-pkg-repo-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "find-cache-dir": "^3.2.0",
     "find-up": "^4.1.0",
     "foreground-child": "^2.0.0",
+    "get-package-type": "^0.1.0",
     "glob": "^7.1.6",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-hook": "^3.0.0",

--- a/tap-snapshots/test-nyc-integration.js-TAP.test.js
+++ b/tap-snapshots/test-nyc-integration.js-TAP.test.js
@@ -5,6 +5,18 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
+exports[`test/nyc-integration.js TAP --all does not fail on ERR_REQUIRE_ESM > stdout 1`] = `
+------------|---------|----------|---------|---------|-------------------
+File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+------------|---------|----------|---------|---------|-------------------
+All files   |   33.33 |      100 |       0 |   33.33 |                   
+ extra.mjs  |       0 |      100 |       0 |       0 | 2                 
+ index.js   |       0 |      100 |       0 |       0 | 2                 
+ script.cjs |     100 |      100 |     100 |     100 |                   
+------------|---------|----------|---------|---------|-------------------
+
+`
+
 exports[`test/nyc-integration.js TAP --all includes files with both .map files and inline source-maps > stdout 1`] = `
 ----------|---------|----------|---------|---------|-------------------
 File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 

--- a/test/fixtures/all-type-module/extra.mjs
+++ b/test/fixtures/all-type-module/extra.mjs
@@ -1,0 +1,3 @@
+export default function () {
+	return 'es module';
+}

--- a/test/fixtures/all-type-module/index.js
+++ b/test/fixtures/all-type-module/index.js
@@ -1,0 +1,3 @@
+export default function () {
+	return 'es module';
+}

--- a/test/fixtures/all-type-module/package.json
+++ b/test/fixtures/all-type-module/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "all-type-module",
+  "version": "0.1.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "nyc": {
+    "all": true
+  }
+}

--- a/test/fixtures/all-type-module/script.cjs
+++ b/test/fixtures/all-type-module/script.cjs
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+'use strict';
+
+// Not doing anything, we just want something to run with `nyc --all`
+process.exit(0);

--- a/test/nyc-integration.js
+++ b/test/nyc-integration.js
@@ -15,6 +15,7 @@ const nycConfigJS = path.resolve(fixturesCLI, 'nyc-config-js')
 const nycrcDir = path.resolve(fixturesCLI, 'nycrc')
 const fixturesSourceMaps = path.resolve(fixturesCLI, '../source-maps')
 const fixturesENM = path.resolve(fixturesCLI, '../exclude-node-modules')
+const fixturesAllTypeModule = path.resolve(fixturesCLI, '../all-type-module')
 
 const executeNodeModulesArgs = [
   '--all=true',
@@ -434,6 +435,15 @@ t.test('--all uses source-maps to exclude original sources from reports', t => t
     './instrumented/s1.min.js'
   ],
   cwd: fixturesSourceMaps
+}))
+
+t.test('--all does not fail on ERR_REQUIRE_ESM', t => testSuccess(t, {
+  args: [
+    '--all',
+    process.execPath,
+    'script.cjs'
+  ],
+  cwd: fixturesAllTypeModule
 }))
 
 t.test('caches source-maps from .map files', async t => {


### PR DESCRIPTION
This allows `--all` to collect initial coverage from fils which node.js
recognizes as ES modules (`.mjs` files and conditionally `.js` files).
Previously this would cause node.js to produce an `ERR_REQUIRE_ESM`
error.

This does not enable collection of coverage during actual tests, for that
you must use the experimental `@istanbuljs/esm-loader-hook`.