### PR TITLE
chore: Tweak self-coverage implementation

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -4,5 +4,9 @@
 	"jobs": 1,
 	"timeout": 360,
 	"bail": false,
-	"esm": false
+	"esm": false,
+	"node-arg": [
+		"--require",
+		"./self-coverage-helper.js"
+	]
 }

--- a/index.js
+++ b/index.js
@@ -24,16 +24,11 @@ const getPackageType = require('get-package-type')
 
 const debugLog = debuglog('nyc')
 
-let selfCoverageHelper
-
+const nycSelfCoverageHelper = Symbol.for('nyc self-test coverage helper')
 /* istanbul ignore next */
-if (/self-coverage/.test(__dirname)) {
-  selfCoverageHelper = require('../self-coverage-helper')
-} else {
+const selfCoverageHelper = global[nycSelfCoverageHelper] || {
   // Avoid additional conditional code
-  selfCoverageHelper = {
-    onExit () {}
-  }
+  onExit () {}
 }
 
 function coverageFinder () {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "standard": "^14.3.1",
     "standard-version": "^8.0.0",
     "tap": "^14.10.5",
+    "uuid": "^3.4.0",
     "which": "^2.0.2"
   },
   "engines": {


### PR DESCRIPTION
This avoids the conditional `require('../self-coverage-helper')` which
can create difficulty for code analysis.  Also use uuid v4 to generate
self coverage filenames instead of process.pid.