### PR TITLE
Add introductory section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Istanbul's state of the art command line interface, with support for:
 * applications that spawn subprocesses.
 * source mapped coverage of Babel and TypeScript projects
 
+## How Istanbul works
+
+Istanbul instruments your ES5 and ES2015+ JavaScript code with line counters, so that you can track how well your unit-tests exercise your codebase.
+
+The `nyc` command-line-client for Istanbul works well with most JavaScript testing frameworks: tap, mocha, AVA, etc.
+
 ## Installation & Usage
 
 Use your package manager to add it as a dev dependency: `npm i -D nyc` or `yarn add -D nyc`.


### PR DESCRIPTION
Awasome project! thanks.

That said, I came to this project because IntelliJ suggested me to use it in order to execute mocha tests with code coverage, so like any developer, before accept the IntelliJ suggestion I went to the official Npm section to see what is this package about, and like here in the Github README, you can see a lot of links and information but not what `ncy` actually does, so I just copy&pasted the introductory section from the official site.