### PR TITLE
Preservation of actual extensions specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,6 @@ class NYC {
 
     this.extensions = [].concat(config.extension || [])
       .concat('.js')
-      .map(ext => ext.toLowerCase())
       .filter((item, pos, arr) => arr.indexOf(item) === pos)
 
     this.exclude = new TestExclude({
@@ -268,7 +267,7 @@ class NYC {
   }
 
   _transform (code, filename) {
-    const extname = path.extname(filename).toLowerCase()
+    const extname = path.extname(filename)
     const transform = this.transforms[extname] || (() => null)
 
     return transform(code, { filename })


### PR DESCRIPTION
Upper case characters are being transformed into lower case characters currently.  

This would keep extensions exactly as they are specified.