### PR TITLE
Updated Package of yargs for fixing the vulnerability of y18n

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "signal-exit": "^3.0.2",
     "spawn-wrap": "^2.0.0",
     "test-exclude": "^6.0.0",
-    "yargs": "^15.0.2"
+    "yargs": "^16.2.0"
   },
   "devDependencies": {
     "any-path": "^1.3.0",


### PR DESCRIPTION
There is a vulnerability in the y18n npm package.
This affects the package y18n before 3.2.2, 4.0.1, and 5.0.5. 

https://www.npmjs.com/package/yargs
Yargs have updated the version of y18n  in its updated version 16.2.0

```
"y18n": "^5.0.5",
```