### PR TITLE
Bump yargs package to fix CVE-2020-7774 vulnerability.

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "signal-exit": "^3.0.2",
     "spawn-wrap": "^2.0.0",
     "test-exclude": "^6.0.0",
-    "yargs": "^15.0.2"
+    "yargs": "^17.0.1"
   },
   "devDependencies": {
     "any-path": "^1.3.0",


### PR DESCRIPTION
Bump yargs package to fix CVE-2020-7774 vulnerability.