### PR TITLE
Fix concurrent access to result map when merging coverage

### DIFF
--- a/index.js
+++ b/index.js
@@ -418,16 +418,18 @@ class NYC {
   }
 
   async getCoverageMapFromAllCoverageFiles (baseDirectory) {
-    const map = libCoverage.createCoverageMap({})
     const files = await this.coverageFiles(baseDirectory)
 
-    await pMap(
+    const reports = await pMap(
       files,
-      async f => {
-        const report = await this.coverageFileLoad(f, baseDirectory)
-        map.merge(report)
-      },
+      f => this.coverageFileLoad(f, baseDirectory),
       { concurrency: os.cpus().length }
+    )
+    const map = reports.reduce((m, report) => {
+      m.merge(report)
+      return m
+    },
+    libCoverage.createCoverageMap({})
     )
 
     map.data = await this.sourceMaps.remapCoverage(map.data)


### PR DESCRIPTION
resolves #1424 

Note that an alternative implementation could be made using [p-reduce](https://github.com/sindresorhus/p-reduce) which might be slightly more efficient as it could start processing whilst files are still in the process of being loaded. However, this would require switching to ESM ... hence I decided on a simpler approach without introducing a new dependency for now (it also would not support limit concurrency at the moment, https://github.com/sindresorhus/p-reduce/issues/4, thus requiring another dependency to [p-limit](https://github.com/sindresorhus/p-limit)).