### PR TITLE
build: replace deprecated uuid dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "standard": "^14.3.1",
     "standard-version": "^9.0.0",
     "tap": "^14.10.5",
-    "uuid": "^3.4.0",
+    "uuid": "^8.3.2",
     "which": "^2.0.2"
   },
   "engines": {

--- a/self-coverage-helper.js
+++ b/self-coverage-helper.js
@@ -2,7 +2,7 @@
 
 const path = require('path')
 const fs = require('fs')
-const uuid = require('uuid/v4')
+const { v4: uuid } = require('uuid')
 const mkdirp = require('make-dir')
 const onExit = require('signal-exit')
 const nodePreload = require('node-preload')


### PR DESCRIPTION
UUID 3 is deprecated

`Please upgrade to version 7 or higher. Older versions may use Math.random() in certain circumstances, which is known to be problematic. See https://v8.dev/blog/math-random for details.`

Upgrading it will be very helpful to push things along for libraries depending on this.

Thanks!