### PR TITLE
chore: remove git.io

### DIFF
--- a/lib/config-util.js
+++ b/lib/config-util.js
@@ -31,7 +31,7 @@ async function processConfig (cwd) {
     .example('$0 npm test', 'instrument your tests with coverage')
     .example('$0 --require @babel/register npm test', 'instrument your tests with coverage and transpile with Babel')
     .example('$0 report --reporter=text-lcov', 'output lcov report after running your tests')
-    .epilog('visit https://git.io/vHysA for list of available reporters')
+    .epilog('visit https://github.com/istanbuljs/istanbuljs/tree/master/packages/istanbul-reports/lib for list of available reporters')
     .boolean('h')
     .boolean('version')
     .help(false)


### PR DESCRIPTION
All links on git.io will stop redirecting after April 29, 2022.

- https://github.blog/changelog/2022-04-25-git-io-deprecation/