### PR TITLE
Show errors thrown while loading a coverage file

### DIFF
--- a/index.js
+++ b/index.js
@@ -515,6 +515,7 @@ class NYC {
       await this.sourceMaps.reloadCachedSourceMaps(report)
       return report
     } catch (error) {
+      console.error(`There was a problem loading coverage from ${filename} in ${baseDirectory}: ${error}`)
       return {}
     }
   }


### PR DESCRIPTION
This will save a good amount of time for anyone dealing with a badly formatted JSON file.

The current status is that an attempt at merging for badly formatted files will result in an empty JSON giving no clue as why.