### PR TITLE
refactor: remove out-dated argument of istanbul-lib-instrument

### DIFF
--- a/lib/instrumenters/istanbul.js
+++ b/lib/instrumenters/istanbul.js
@@ -7,7 +7,6 @@ function InstrumenterIstanbul (options) {
   const instrumenter = createInstrumenter({
     autoWrap: true,
     coverageVariable: '__coverage__',
-    embedSource: true,
     compact: options.compact,
     preserveComments: options.preserveComments,
     produceSourceMap: options.produceSourceMap,


### PR DESCRIPTION
The `embedSource` argument was removed before `v1` release of `istanbul-lib-instrument`.

https://github.com/istanbuljs/istanbuljs/blob/istanbul-lib-instrument%401.10.0/packages/istanbul-lib-instrument/v0-changes.md#api-changes

> - `embedSource` no longer available. The original source is never packed in with the coverage object. This was causing all manner of special casing in the reporting code.