### PR TITLE
[Security] [Dependency] Bumped istanbul-lib-instrument to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "glob": "^7.1.6",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-hook": "^3.0.0",
-    "istanbul-lib-instrument": "^4.0.0",
+    "istanbul-lib-instrument": "^6.0.2",
     "istanbul-lib-processinfo": "^2.0.2",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",


### PR DESCRIPTION
# What is in this PR?
- Bumping version of `istanbul-lib-instrument` package to the _possible_ version `6.0.2`
    - Refer to this PR for more information: https://github.com/istanbuljs/istanbuljs/pull/762

# Why?

This lovely library uses `istanbul-lib-instrument` and that packages has an earlier version of babel which has this security vulnerability.
https://security.snyk.io/vuln/SNYK-JS-BABELTRAVERSE-5962462

Updating this package after merging the above PR will solve this dependency chain vulnerability with minimal impact to end users.

Let me know if you all have any questions or if there's anything I can do to improve this PR 🙂. I'd be more than happy to!! 

