### PR TITLE
[Breaking Change] Node Upgrade to >=20.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyc",
-  "version": "15.1.0",
+  "version": "16.1.0",
   "description": "the Istanbul command line interface",
   "main": "index.js",
   "scripts": {
@@ -56,7 +56,7 @@
   "author": "Ben Coe <ben@npmjs.com>",
   "license": "ISC",
   "dependencies": {
-    "@istanbuljs/load-nyc-config": "^1.0.0",
+    "@istanbuljs/load-nyc-config": "^1.1.0",
     "@istanbuljs/schema": "^0.1.2",
     "caching-transform": "^4.0.0",
     "convert-source-map": "^1.7.0",
@@ -92,12 +92,12 @@
     "source-map-support": "^0.5.16",
     "standard": "^14.3.1",
     "standard-version": "^9.0.0",
-    "tap": "^14.10.5",
+    "tap": "^18.7.0",
     "uuid": "^3.4.0",
     "which": "^2.0.2"
   },
   "engines": {
-    "node": ">=8.9"
+    "node": ">=20.0.0"
   },
   "homepage": "https://istanbul.js.org/",
   "bugs": "https://github.com/istanbuljs/nyc/issues",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "glob": "^7.1.6",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-hook": "^3.0.0",
-    "istanbul-lib-instrument": "^4.0.0",
+    "istanbul-lib-instrument": "^6.0.2",
     "istanbul-lib-processinfo": "^2.0.2",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",


### PR DESCRIPTION
# What is in this PR?
- Bumping version of the required node version to LTS `>=v20.0.0`

# Why?
Current node version is not maintained.

Additional Info:
Currently getting this error below while running `npm run test`
<img width="914" alt="Screenshot 2024-02-26 at 8 13 17 PM" src="https://github.com/istanbuljs/nyc/assets/11778717/2c3f2d57-d2a6-4c1b-bdcc-965e71e48e97">

I did an `npm list jackspeak` to see further where this package is since it's not in the top-level dependency tree. This was the result. For context, I did upgrade tap to the latest version, `18.7.0`.
<img width="486" alt="Screenshot 2024-02-26 at 8 17 30 PM" src="https://github.com/istanbuljs/nyc/assets/11778717/b65ff3f8-9614-4743-b915-23975f3cb1db">


Would love some eyes on what you might think could be the issue. I'll continue hacking away at debugging this error! @bcoe  🙂 

