### PR TITLE
fix `nyc merge` stringify hitting Invalid string length

### DIFF
--- a/lib/commands/merge.js
+++ b/lib/commands/merge.js
@@ -41,6 +41,6 @@ exports.handler = cliWrapper(async argv => {
   }
   await makeDir(path.dirname(argv.outputFile))
   const map = await nyc.getCoverageMapFromAllCoverageFiles(argv.inputDirectory)
-  await fs.writeFile(argv.outputFile, JSON.stringify(map, null, 2), 'utf8')
+  await fs.writeFile(argv.outputFile, JSON.stringify(map), 'utf8')
   console.info(`coverage files in ${argv.inputDirectory} merged into ${argv.outputFile}`)
 })


### PR DESCRIPTION
Fixes https://github.com/istanbuljs/nyc/issues/1451

`null, 2` pretty prints the json but this adds so much white space we hit the node limitation in string sizes https://github.com/nodejs/node/issues/35973#issuecomment-722253319