### PR TITLE
fix: sanitize invalid Windows chars in HTML report paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const onExit = require('signal-exit')
 const path = require('path')
 const { rimraf } = require('rimraf')
 const SourceMaps = require('./lib/source-maps')
+const { sanitizeCoveragePaths } = require('./lib/sanitize-coverage-paths')
 const TestExclude = require('test-exclude')
 const pMap = require('p-map')
 const getPackageType = require('get-package-type')
@@ -430,7 +431,7 @@ class NYC {
       { concurrency: os.cpus().length }
     )
 
-    map.data = await this.sourceMaps.remapCoverage(map.data)
+    map.data = sanitizeCoveragePaths(await this.sourceMaps.remapCoverage(map.data))
 
     // depending on whether source-code is pre-instrumented
     // or instrumented using a JIT plugin like @babel/require

--- a/lib/sanitize-coverage-paths.js
+++ b/lib/sanitize-coverage-paths.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const libCoverage = require('istanbul-lib-coverage')
+
+// Characters that cannot appear in a Windows path segment. Colon is included
+// because sourcemap sources such as `angular:script` are not drive letters.
+const INVALID_SEGMENT_CHARS = /[<>:"|?*]/g
+
+function sanitizePathSegments (filePath) {
+  if (typeof filePath !== 'string' || filePath.length === 0) {
+    return filePath
+  }
+
+  const driveMatch = filePath.match(/^([A-Za-z]:)([\\/])/)
+  let prefix = ''
+  let rest = filePath
+  if (driveMatch) {
+    prefix = driveMatch[1] + driveMatch[2]
+    rest = filePath.slice(prefix.length)
+  } else if (filePath.charAt(0) === '/' || filePath.charAt(0) === '\\') {
+    prefix = filePath.charAt(0)
+    rest = filePath.slice(1)
+  }
+
+  const separator = driveMatch && filePath.indexOf('\\') !== -1 ? '\\' : '/'
+  return prefix + rest.split(/[/\\]/).map(segment => (
+    segment.replace(INVALID_SEGMENT_CHARS, '_')
+  )).join(separator)
+}
+
+function coverageRecordWithPath (coverage, filePath) {
+  if (!coverage || typeof coverage !== 'object') {
+    return coverage
+  }
+
+  if (typeof coverage.toJSON === 'function') {
+    const json = coverage.toJSON()
+    json.path = filePath
+    return libCoverage.createFileCoverage(json)
+  }
+
+  const copy = Object.assign({}, coverage)
+  copy.path = filePath
+  return copy
+}
+
+function sanitizeCoveragePaths (data) {
+  const result = {}
+  if (!data || typeof data !== 'object') {
+    return result
+  }
+
+  Object.keys(data).forEach(filePath => {
+    const safePath = sanitizePathSegments(filePath)
+    result[safePath] = coverageRecordWithPath(data[filePath], safePath)
+  })
+
+  return result
+}
+
+module.exports = {
+  sanitizePathSegments,
+  sanitizeCoveragePaths
+}

--- a/test/report.js
+++ b/test/report.js
@@ -49,3 +49,73 @@ t.test('allows coverage report to be output in an alternative directory', async 
   t.equal(fs.existsSync('./alternative-report/lcov.info'), true)
   await rimraf('./alternative-report')
 })
+
+function listFiles (dir) {
+  if (!fs.existsSync(dir)) {
+    return []
+  }
+
+  return fs.readdirSync(dir).reduce((files, name) => {
+    const full = path.join(dir, name)
+    if (fs.statSync(full).isDirectory()) {
+      return files.concat(listFiles(full))
+    }
+    files.push(full)
+    return files
+  }, [])
+}
+
+t.test('html reporter sanitizes sourcemap sources with invalid Windows filename characters', async t => {
+  const tempDir = path.resolve('./.nyc_output_html_invalid_chars')
+  const reportDir = path.resolve('./coverage-html-invalid-chars')
+  await rimraf(tempDir)
+  await rimraf(reportDir)
+  fs.mkdirSync(tempDir, { recursive: true })
+
+  // Remapped coverage whose original sourcemap `sources` included angular:script
+  // (and other Windows-illegal filename characters).
+  const coverage = {
+    'angular:script': {
+      path: 'angular:script',
+      statementMap: {
+        0: { start: { line: 1, column: 0 }, end: { line: 1, column: 14 } }
+      },
+      fnMap: {},
+      branchMap: {},
+      s: { 0: 1 },
+      f: {},
+      b: {},
+      inputSourceMap: {
+        version: 3,
+        file: 'generated.js',
+        sources: ['angular:script'],
+        names: [],
+        mappings: 'AAAA',
+        sourcesContent: ['console.log(1)\n']
+      }
+    }
+  }
+  fs.writeFileSync(path.join(tempDir, 'coverage.json'), JSON.stringify(coverage))
+
+  const nyc = new NYC(await parseArgv(undefined, [
+    `--temp-dir=${tempDir}`,
+    `--report-dir=${reportDir}`,
+    '--reporter=html',
+    '--exclude-after-remap=false'
+  ]))
+  await nyc.report()
+
+  const files = listFiles(reportDir)
+  t.ok(files.length > 0, 'html report wrote files')
+  t.ok(
+    files.every(file => !/[<>:"|?*]/.test(path.relative(reportDir, file))),
+    'report paths do not contain Windows-illegal filename characters'
+  )
+  t.ok(
+    files.some(file => path.relative(reportDir, file).includes('angular_script')),
+    'sanitized angular:script source is present in the html report'
+  )
+
+  await rimraf(tempDir)
+  await rimraf(reportDir)
+})

--- a/test/sanitize-coverage-paths.js
+++ b/test/sanitize-coverage-paths.js
@@ -1,0 +1,48 @@
+'use strict'
+
+const t = require('tap')
+const {
+  sanitizePathSegments,
+  sanitizeCoveragePaths
+} = require('../lib/sanitize-coverage-paths')
+
+t.test('replaces Windows-invalid characters in a path segment', t => {
+  t.equal(sanitizePathSegments('angular:script'), 'angular_script')
+  t.equal(sanitizePathSegments('foo?bar'), 'foo_bar')
+  t.equal(sanitizePathSegments('a<b>c'), 'a_b_c')
+  t.equal(sanitizePathSegments('x|y*z'), 'x_y_z')
+  t.equal(sanitizePathSegments('quote"name'), 'quote_name')
+  t.end()
+})
+
+t.test('preserves POSIX and Windows roots', t => {
+  t.equal(sanitizePathSegments('/src/app.js'), '/src/app.js')
+  t.equal(sanitizePathSegments('C:\\src\\app.js'), 'C:\\src\\app.js')
+  t.equal(
+    sanitizePathSegments('C:\\src\\angular:script'),
+    'C:\\src\\angular_script'
+  )
+  t.equal(
+    sanitizePathSegments('/generated/angular:script'),
+    '/generated/angular_script'
+  )
+  t.end()
+})
+
+t.test('rewrites coverage map keys and path fields', t => {
+  const sanitized = sanitizeCoveragePaths({
+    'angular:script': {
+      path: 'angular:script',
+      s: { 0: 1 }
+    },
+    '/src/ok.js': {
+      path: '/src/ok.js',
+      s: { 0: 2 }
+    }
+  })
+
+  t.same(Object.keys(sanitized).sort(), ['/src/ok.js', 'angular_script'])
+  t.equal(sanitized['angular_script'].path, 'angular_script')
+  t.equal(sanitized['/src/ok.js'].path, '/src/ok.js')
+  t.end()
+})


### PR DESCRIPTION
Sourcemap `sources` such as `angular:script` become coverage keys and then HTML filenames. On Windows those characters (`? < > : * | "`) make `nyc report --reporter html` fail.

After remapping, each path segment is sanitized before the reporter writes files. Drive-letter prefixes (`C:\`) are left intact.

## Test plan
- [x] `npx tap test/sanitize-coverage-paths.js test/report.js` (18/18)
- Unsanitized HTML output is `angular:script.html`; after this change it is `angular_script.html`

Fixes #1621

Made with [Cursor](https://cursor.com)